### PR TITLE
Remove default color of LoadingSpinner

### DIFF
--- a/src/loading-spinner/LoadingSpinner.js
+++ b/src/loading-spinner/LoadingSpinner.js
@@ -26,7 +26,6 @@ const LoadingSpinner = React.createClass({
   getDefaultProps() {
     return {
       size: '3em',
-      color: 'grey',
       overlayColor: 'rgba(255, 255, 255, .9)'
     };
   },


### PR DESCRIPTION
`LoadingSpinner` shouldn't have a default color, so that it's able to inherit from container