### PR TITLE
#49: [Popover] rename misleading type props "absolute" and "relative" (closes #49)

### DIFF
--- a/examples/components/Popover.js
+++ b/examples/components/Popover.js
@@ -32,14 +32,14 @@ const Example = React.createClass({
     return (
       <div>
         <div style={{marginTop: 200, marginLeft: 130}}>
-          <Popover popover={{content, position: 'bottom', anchor: 'left', type: 'absolute', event: 'click'}}>
+          <Popover popover={{content, position: 'bottom', anchor: 'left', attachToBody: true, event: 'click'}}>
             <button ref='target' onClick={this.toggle} style={{backgroundColor: 'green', display: 'inline-block'}}>
               ABSOLUTE
             </button>
           </Popover>
         </div>
         <div style={{marginTop: 200, marginLeft: 130}}>
-          <Popover popover={{content, position: 'top', anchor: 'right', type: 'relative'}}>
+          <Popover popover={{content, position: 'top', anchor: 'right'}}>
             <button ref='target' onClick={this.toggle} style={{backgroundColor: 'green', display: 'inline-block'}}>
               RELATIVE
             </button>

--- a/src/popover/Popover.js
+++ b/src/popover/Popover.js
@@ -7,7 +7,7 @@ const Popover = React.createClass({
     children: React.PropTypes.node.isRequired,
     popover: React.PropTypes.shape({
       content: React.PropTypes.node.isRequired,
-      type: React.PropTypes.oneOf(['absolute', 'relative']),
+      attachToBody: React.PropTypes.bool,
       position: React.PropTypes.oneOf(['top', 'bottom']),
       anchor: React.PropTypes.oneOf(['left', 'center', 'right']),
       event: React.PropTypes.oneOf(['click', 'hover']),
@@ -223,7 +223,7 @@ const Popover = React.createClass({
   },
 
   isAbsolute() {
-    return this.getPopoverProps().type === 'absolute';
+    return this.getPopoverProps().attachToBody === true;
   },
 
   computePopoverStyle() {
@@ -273,7 +273,7 @@ const Popover = React.createClass({
   },
 
   getLocals() {
-    const isRelative = this.getPopoverProps().type === 'relative';
+    const isRelative = !this.isAbsolute();
     const { isOpen } = this.state;
     const popover = isRelative && (isOpen ? this.getVisiblePopover() : this.getHiddenPopover());
     return {


### PR DESCRIPTION
Issue #49