### PR TITLE
safer ModalManager children.map

### DIFF
--- a/src/modal-manager/ModalManager.js
+++ b/src/modal-manager/ModalManager.js
@@ -63,7 +63,7 @@ const ModalManager = React.createClass({
       hAlignContent: 'center'
     };
 
-    return React.Children.map(children, el => {
+    return [].concat(children).filter(e => !!e).map(el => {
       if (!el.key) {
         this.logWarning('Each modal should have a unique "key" prop');
       }


### PR DESCRIPTION
React threats `undefined` and `false` children differently: `children = []` and `children = [<noscript />]` respectively

This should prevent issues when rendering `<ModalManager>{false}</ModalManager>`