### PR TITLE
#143: [TextOverflow] verify if setTimeout is needed (closes #143)

### DIFF
--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -50,7 +50,7 @@ const TextOverflow = React.createClass({
       if(text.offsetWidth < text.scrollWidth){
         this.setState({ isOverflowing: true });
       }
-      setTimeout(this.logWarnings);
+      this.logWarnings();
     }
   },
 


### PR DESCRIPTION
Issue #143

The `setTimeout` seemed useless and it was the cause of some exceptions when the component was forced to render.
Consider `setTimeout()` with no delay put its callback in the next execution queue, the forced rendered `TextOverflow` threw exception if the component has unmounted in the meantime.

<img width="656" alt="screen shot 2016-01-04 at 12 37 51" src="https://cloud.githubusercontent.com/assets/1838567/12088941/19e1df0a-b2e0-11e5-9e7c-be99a7bb95a3.png">

The attachment shows the lifecycle of `TextOverflow` components.