### PR TITLE
#168: center expand button in MoreOrLess (closes #168)

### DIFF
--- a/src/more-or-less/MoreOrLess.js
+++ b/src/more-or-less/MoreOrLess.js
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import { pure, props, t, skinnable } from '../utils';
 import { Icon } from '../Icon';
+import { FlexView } from '../flex';
 
 
 @pure
@@ -42,9 +43,14 @@ export default class MoreOrLess extends React.Component {
 
   templateExpandButton = ({ icon, toggleExpanded }) => {
     return (
-      <div className='expand-button' onClick={toggleExpanded}>
-        <Icon icon={icon} className='expand-button-icon' />
-      </div>
+      <FlexView
+        hAlignContent="center"
+        vAlignContent="center"
+        className="expand-button"
+        onClick={toggleExpanded}
+      >
+        <Icon icon={icon} className="expand-button-icon" />
+      </FlexView>
     );
   }
 

--- a/src/more-or-less/moreOrLess.scss
+++ b/src/more-or-less/moreOrLess.scss
@@ -7,7 +7,6 @@ $expand-button-icon-color: #999 !default;
     width: 100%;
     height: 15px;
     cursor: pointer;
-    text-align: center;
     background: $expand-button-background;
 
     &:hover {


### PR DESCRIPTION
Issue #168