### PR TITLE
#200: LoadingSpinner container being position absolute is ok (closes #200)

### DIFF
--- a/src/loading-spinner/LoadingSpinner.js
+++ b/src/loading-spinner/LoadingSpinner.js
@@ -70,8 +70,8 @@ const LoadingSpinner = React.createClass({
   logWarnings() {
     warn(() => {
       const { position } = this.refs.loadingSpinner.getDOMNode().parentNode.style;
-      if (position !== 'relative') {
-        return 'LoadingSpinner\'s parent node style should have "position: relative"';
+      if (position !== 'relative' && position !== 'absolute') {
+        return 'LoadingSpinner\'s parent node style should have "position: relative" or "position: absolute"';
       }
     });
   },


### PR DESCRIPTION
Issue #200

## Test Plan
- `LoadingSpinner` should not log warnings anymore if its container has `position: absolute` 