### PR TITLE
#220: remove old margin-top to .expand-icon in panel.scss' (closes #220)

### DIFF
--- a/src/Panel/panel.scss
+++ b/src/Panel/panel.scss
@@ -66,7 +66,6 @@
 
     .expand-icon {
       font-size: 20px;
-      margin-top: -4px;
     }
 
     .panel-header-title {


### PR DESCRIPTION
Issue #220