### PR TITLE
#305: [FlexView] basis should append 'px' also to string numbers (closes #305)

### DIFF
--- a/src/flex/FlexView.js
+++ b/src/flex/FlexView.js
@@ -99,7 +99,7 @@ export default class FlexView extends React.Component {
   getBasis = () => {
     const { basis } = this.props;
     if (basis) {
-      const suffix = t.Number.is(basis) ? 'px' : '';
+      const suffix = t.Number.is(basis) || String(parseInt(basis, 10)) === basis ? 'px' : '';
       return basis + suffix;
     }
 


### PR DESCRIPTION
Issue #305 

**test plan**
- `<FlexVIew basis="200" />` -> `flex: 0 0 200px`
- `<FlexVIew basis="200a" />` -> `flex: 0 0 200a`