### PR TITLE
#351: [background-dimmer] content should scroll when too big (closes #351)

### DIFF
--- a/src/background-dimmer/BackgroundDimmer.js
+++ b/src/background-dimmer/BackgroundDimmer.js
@@ -46,7 +46,7 @@ export default class BackgroundDimmer extends React.Component {
 
   isEventOutsideChildren = (e) => {
     const el = e.target || e.srcElement;
-    return el === React.findDOMNode(this.refs.flexWrapper);
+    return el === React.findDOMNode(this.refs.mainContentWrapper);
   };
 
   onClick = (e) => {
@@ -85,23 +85,24 @@ export default class BackgroundDimmer extends React.Component {
           opacity: String(alpha)
         }
       },
-      flexViewProps: {
+      mainContentWrapperProps: {
         onClick,
         onWheel: stopScrollPropagation,
         onTouchMove: stopScrollPropagation,
         style: { ...fixedStyle, zIndex: (zIndex + 1) },
+        className: 'main-content-wrapper',
         vAlignContent: 'center',
         hAlignContent: 'center',
-        ref: 'flexWrapper'
+        ref: 'mainContentWrapper'
       }
     };
   }
 
-  template({ children, overlayProps, flexViewProps, stopPropagation, ...locals }) {
+  template({ children, overlayProps, mainContentWrapperProps, stopPropagation, ...locals }) {
     return (
       <div {...locals}>
         <div {...overlayProps} />
-        <FlexView {...flexViewProps}>
+        <FlexView {...mainContentWrapperProps}>
           <div onClick={stopPropagation}>
             {children}
           </div>

--- a/src/background-dimmer/BackgroundDimmer.js
+++ b/src/background-dimmer/BackgroundDimmer.js
@@ -94,18 +94,23 @@ export default class BackgroundDimmer extends React.Component {
         vAlignContent: 'center',
         hAlignContent: 'center',
         ref: 'mainContentWrapper'
+      },
+      centeredContentWrapperProps: {
+        className: 'centered-content-wrapper',
+        onClick: stopPropagation,
+        column: true
       }
     };
   }
 
-  template({ children, overlayProps, mainContentWrapperProps, stopPropagation, ...locals }) {
+  template({ children, overlayProps, mainContentWrapperProps, centeredContentWrapperProps, ...locals }) {
     return (
       <div {...locals}>
         <div {...overlayProps} />
         <FlexView {...mainContentWrapperProps}>
-          <div onClick={stopPropagation}>
+          <FlexView {...centeredContentWrapperProps}>
             {children}
-          </div>
+          </FlexView>
         </FlexView>
       </div>
     );

--- a/src/background-dimmer/BackgroundDimmer.js
+++ b/src/background-dimmer/BackgroundDimmer.js
@@ -31,6 +31,14 @@ import FlexView from '../flex/FlexView';
    * called when user clicks outside children
    */
   onClickOutside: t.maybe(t.Function),
+  /**
+   * centeredContentWrapper max-width
+   */
+  maxWidth: t.maybe(t.union([t.String, t.Number])),
+  /**
+   * centeredContentWrapper max-height
+   */
+  maxHeight: t.maybe(t.union([t.String, t.Number])),
   className: t.maybe(t.String),
   id: t.maybe(t.String),
   style: t.maybe(t.Object)
@@ -41,7 +49,9 @@ export default class BackgroundDimmer extends React.Component {
   static defaultProps = {
     color: 'black',
     alpha: 0.5,
-    zIndex: 99999
+    zIndex: 99999,
+    maxWidth: '90%',
+    maxHeight: '90%'
   };
 
   isEventOutsideChildren = (e) => {
@@ -69,7 +79,7 @@ export default class BackgroundDimmer extends React.Component {
   getLocals() {
     const {
       onClick, stopPropagation, stopScrollPropagation,
-      props: { className, zIndex, color, alpha, ...props }
+      props: { className, zIndex, color, alpha, maxWidth, maxHeight, ...props }
     } = this;
 
     const fixedStyle = { position: 'fixed', top: 0, left: 0, right: 0, bottom: 0 };
@@ -97,7 +107,7 @@ export default class BackgroundDimmer extends React.Component {
       },
       centeredContentWrapperProps: {
         className: 'centered-content-wrapper',
-        style: { maxHeight: '90%', maxWidth: '90%' },
+        style: { maxWidth, maxHeight },
         onClick: stopPropagation,
         column: true
       }

--- a/src/background-dimmer/BackgroundDimmer.js
+++ b/src/background-dimmer/BackgroundDimmer.js
@@ -51,14 +51,14 @@ export default class BackgroundDimmer extends React.Component {
 
   onClick = (e) => {
     const { onClickOutside } = this.props;
-    if (this.props.onClickOutside) {
+    if (onClickOutside) {
       onClickOutside(e);
     }
   };
 
   stopPropagation = e => e.stopPropagation();
 
-  preventDefault = (e) => e.preventDefault();
+  preventDefault = e => e.preventDefault();
 
   stopScrollPropagation = (e) => {
     if (this.props.stopScrollPropagation && this.isEventOutsideChildren(e)) {

--- a/src/background-dimmer/BackgroundDimmer.js
+++ b/src/background-dimmer/BackgroundDimmer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import cx from 'classnames';
 import { props, t, skinnable } from '../utils';
 import FlexView from '../flex/FlexView';
 
@@ -68,13 +69,14 @@ export default class BackgroundDimmer extends React.Component {
   getLocals() {
     const {
       onClick, stopPropagation, stopScrollPropagation,
-      props: { zIndex, color, alpha, ...props }
+      props: { className, zIndex, color, alpha, ...props }
     } = this;
 
     const fixedStyle = { position: 'fixed', top: 0, left: 0, right: 0, bottom: 0 };
     return {
       ...props,
       stopPropagation,
+      className: cx('background-dimmer', className),
       overlayProps: {
         style: {
           ...fixedStyle,

--- a/src/background-dimmer/BackgroundDimmer.js
+++ b/src/background-dimmer/BackgroundDimmer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { props, t } from '../utils';
+import { props, t, skinnable } from '../utils';
 import FlexView from '../flex/FlexView';
 
 /**
@@ -34,6 +34,7 @@ import FlexView from '../flex/FlexView';
   id: t.maybe(t.String),
   style: t.maybe(t.Object)
 })
+@skinnable()
 export default class BackgroundDimmer extends React.Component {
 
   static defaultProps = {
@@ -64,28 +65,42 @@ export default class BackgroundDimmer extends React.Component {
     }
   };
 
-  render() {
-    const { style, className, id, children, zIndex, color, alpha } = this.props;
+  getLocals() {
+    const {
+      onClick, stopPropagation, stopScrollPropagation,
+      props: { zIndex, color, alpha, ...props }
+    } = this;
+
     const fixedStyle = { position: 'fixed', top: 0, left: 0, right: 0, bottom: 0 };
-
-    const props = { id, className, style };
-    const flexViewProps = {
-      style: { ...fixedStyle, zIndex: (zIndex + 1) },
-      vAlignContent: 'center',
-      hAlignContent: 'center'
+    return {
+      ...props,
+      stopPropagation,
+      overlayProps: {
+        style: {
+          ...fixedStyle,
+          zIndex,
+          backgroundColor: color,
+          opacity: String(alpha)
+        }
+      },
+      flexViewProps: {
+        onClick,
+        onWheel: stopScrollPropagation,
+        onTouchMove: stopScrollPropagation,
+        style: { ...fixedStyle, zIndex: (zIndex + 1) },
+        vAlignContent: 'center',
+        hAlignContent: 'center',
+        ref: 'flexWrapper'
+      }
     };
+  }
 
+  template({ children, overlayProps, flexViewProps, stopPropagation, ...locals }) {
     return (
-      <div {...props}>
-        <div style={{ ...fixedStyle, zIndex, backgroundColor: color, opacity: String(alpha) }} />
-        <FlexView
-          {...flexViewProps}
-          onClick={this.onClick}
-          onWheel={this.stopScrollPropagation}
-          onTouchMove={this.stopScrollPropagation}
-          ref='flexWrapper'
-        >
-          <div onClick={this.stopPropagation}>
+      <div {...locals}>
+        <div {...overlayProps} />
+        <FlexView {...flexViewProps}>
+          <div onClick={stopPropagation}>
             {children}
           </div>
         </FlexView>

--- a/src/background-dimmer/BackgroundDimmer.js
+++ b/src/background-dimmer/BackgroundDimmer.js
@@ -97,6 +97,7 @@ export default class BackgroundDimmer extends React.Component {
       },
       centeredContentWrapperProps: {
         className: 'centered-content-wrapper',
+        style: { maxHeight: '90%', maxWidth: '90%' },
         onClick: stopPropagation,
         column: true
       }


### PR DESCRIPTION
Issue #351

![image](https://cloud.githubusercontent.com/assets/4029499/13781675/7239eb22-eac4-11e5-973a-5ddcbee781c4.png)

- if content is higher/wider than 90% of window it correctly scrolls! (if `children` has `overflow: scroll` of course :dancer: )
