### PR TITLE
#360: [TabbedPanel] tabs should have same width (closes #360)

### DIFF
--- a/examples/components/Panel/tabbed.example
+++ b/examples/components/Panel/tabbed.example
@@ -12,7 +12,7 @@ class Example extends React.Component {
     const panelProps = {
       type: 'floating',
       tabs: {
-        headers: [ 'Tab 1', 'Tab 2' ],
+        headers: [ 'Veeery long Tab 1', 'Tab 2' ],
         onSetActiveTab,
         activeIndex: activeTabIndex
       },

--- a/src/Panel/TabbedPanel.js
+++ b/src/Panel/TabbedPanel.js
@@ -38,7 +38,9 @@ export default class TabbedPanel extends React.Component {
     return (
       <FlexView grow className='tabbed-panel-tabs'>
         {headers.map((header, i) => (
-          <FlexView grow
+          <FlexView
+            shrink
+            basis='100%'
             key={i}
             className={cx('tabbed-panel-tab', { active: activeTabIndex === i })}
           >

--- a/src/Panel/TabbedPanel.js
+++ b/src/Panel/TabbedPanel.js
@@ -40,11 +40,7 @@ export default class TabbedPanel extends React.Component {
         {headers.map((header, i) => (
           <FlexView
             shrink
-<<<<<<< Updated upstream
             basis='100%'
-=======
-            basis="100%"
->>>>>>> Stashed changes
             key={i}
             className={cx('tabbed-panel-tab', { active: activeTabIndex === i })}
           >

--- a/src/Panel/TabbedPanel.js
+++ b/src/Panel/TabbedPanel.js
@@ -40,7 +40,11 @@ export default class TabbedPanel extends React.Component {
         {headers.map((header, i) => (
           <FlexView
             shrink
+<<<<<<< Updated upstream
             basis='100%'
+=======
+            basis="100%"
+>>>>>>> Stashed changes
             key={i}
             className={cx('tabbed-panel-tab', { active: activeTabIndex === i })}
           >


### PR DESCRIPTION
Issue #360

## Test Plan

- Open examples page
- Click on `Panel`
- The 3rd example will show you the expected behaviour

Note: if very very long, is not managed. It will be a very uncommon behaviour IMO, to me we can leave it free and make it editable by the user (with `overflow:hidden` or `text-overflow: ellipsis` for instance) 

cc @FrancescoCioria 