### PR TITLE
#409: [DropdownMenu] Menu item is not really vertical centered (closes #409)

### DIFF
--- a/src/DropdownMenu/Menu.js
+++ b/src/DropdownMenu/Menu.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import cx from 'classnames';
 import { pure, props, t, skinnable } from '../utils';
 import partial from 'lodash/partial';
+import FlexView from '../flex/FlexView';
 import Divider from '../Divider/Divider';
 
 import './menu.scss';
@@ -67,14 +68,14 @@ export default class Menu extends React.Component {
 
   menuItemTemplate = (option, onOptionClick) => {
     return (
-      <div className={cx('menu-item', { disabled: option.disabled, selected: option.selected })} onClick={partial(onOptionClick, option)}>
+      <FlexView className={cx('menu-item', { disabled: option.disabled, selected: option.selected })} onClick={partial(onOptionClick, option)} vAlignContent='center'>
         <span className='menu-item-title'>
           {option.title}
         </span>
         <span className='menu-item-metadata'>
           {option.metadata}
         </span>
-      </div>
+      </FlexView>
     );
   };
 


### PR DESCRIPTION
Issue #409

## Test Plan

### tests performed
<img width="267" alt="screen shot 2016-05-04 at 17 17 27" src="https://cloud.githubusercontent.com/assets/1838567/15018945/29401cdc-121c-11e6-8c40-800cab07d5f3.png">

`npm run test` failed due to a wrong import (not related to this pr).