### PR TITLE
#427: [Tooltip] fix Tooltip.popover prop typing (closes #427)

### DIFF
--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -7,11 +7,7 @@ import Popover from '../popover/Popover';
 @skinnable()
 @props({
   children: t.ReactChildren,
-  popover: t.struct({
-    content: t.String,
-    position: t.maybe(t.enums.of(['top', 'bottom', 'left', 'right'])),
-    anchor: t.maybe(t.enums.of(['start', 'center', 'end']))
-  }),
+  popover: t.refinement(t.Object, p => t.String.is(p.content) && t.Nil.is(p.event)),
   type: t.enums.of(['light', 'dark']),
   size: t.enums.of(['small', 'big']),
   className: t.maybe(t.String),


### PR DESCRIPTION
Issue #427

## Test Plan

### tests performed

tested on associated LOL pr: nothing breaks

#### cross browser compatibility

- not applicable

#### display size guidelines

- not applicable

#### unit tests

- unfortunately missing :(

### tests not performed (domain coverage)
everything else
