### PR TITLE
#436: [TextOverflow] Should update also on parent resize (closes #436)

### DIFF
--- a/examples/components/examples.json
+++ b/examples/components/examples.json
@@ -150,7 +150,8 @@
       "examples": [
         "react-components/__TAG__/examples/components/text-overflow/Default.example",
         "react-components/__TAG__/examples/components/text-overflow/CustomPopover.example",
-        "react-components/__TAG__/examples/components/text-overflow/WithFlexView.example"
+        "react-components/__TAG__/examples/components/text-overflow/WithFlexView.example",
+        "react-components/__TAG__/examples/components/text-overflow/Resizable.example"
       ]
     },
     {

--- a/examples/components/text-overflow/Resizable.example
+++ b/examples/components/text-overflow/Resizable.example
@@ -1,0 +1,16 @@
+class Example extends React.Component {
+
+  render() {
+    const label = 'Resize the browser to trigger TextOverflow';
+    return (
+      <TextOverflow style={{ color: 'blue' }} label={label}>
+        {(self) => (
+          <Popover popover={{ content: label }} style={{ color: 'red', width: '100%' }}>
+            {self}
+          </Popover>
+        )}
+      </TextOverflow>
+    );
+  }
+
+}


### PR DESCRIPTION
Issue #436

## Test Plan

### tests performed
[![https://gyazo.com/865b67f71e952420b4b6c9e901f8ad1a](https://i.gyazo.com/865b67f71e952420b4b6c9e901f8ad1a.gif)](https://gyazo.com/865b67f71e952420b4b6c9e901f8ad1a)

#### cross browser compatibility
I didn't directly tested it on IE11 but the only browser-dependent logic is in `ResizeSensor` which works on IE11

### tests not performed (domain coverage)
