### PR TITLE
#439: Badge label should be react children (closes #439)

### DIFF
--- a/src/badge/Badge.js
+++ b/src/badge/Badge.js
@@ -6,7 +6,7 @@ import FlexView from '../flex/FlexView';
 @pure
 @skinnable()
 @props({
-  label: t.union([t.String, t.Number]),
+  label: t.ReactChildren,
   active: t.maybe(t.Boolean),
   className: t.maybe(t.String),
   style: t.maybe(t.Object)


### PR DESCRIPTION
Issue #439

## Test Plan
- it should accept a ReactChildren as label