### PR TITLE
#449: [TextOverflow] remove setTimeouts (closes #449)

### DIFF
--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -71,16 +71,18 @@ export default class TextOverflow extends React.Component {
       const text = ReactDOM.findDOMNode(this.refs.text);
       const textWithoutEllipsis = ReactDOM.findDOMNode(this.refs.textWithoutEllipsis);
 
-      const textWidth = this.getElementWidth(text);
-      const textWithoutEllipsisWidth = this.getElementWidth(textWithoutEllipsis);
+      if (text && textWithoutEllipsis) {
+        const textWidth = this.getElementWidth(text);
+        const textWithoutEllipsisWidth = this.getElementWidth(textWithoutEllipsis);
 
-      const isOverflowing = (textWidth < textWithoutEllipsisWidth);
-      if (isOverflowing) {
-        this.setState({ isOverflowing: true }, this.logWarnings);
-      } else if (force) {
-        this.setState({ isOverflowing: false }, this.logWarnings);
-      } else {
-        this.logWarnings();
+        const isOverflowing = (textWidth < textWithoutEllipsisWidth);
+        if (isOverflowing) {
+          this.setState({ isOverflowing: true }, this.logWarnings);
+        } else if (force) {
+          this.setState({ isOverflowing: false }, this.logWarnings);
+        } else {
+          this.logWarnings();
+        }
       }
     }
   };

--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -30,15 +30,11 @@ export default class TextOverflow extends React.Component {
   }
 
   componentDidMount() {
-    this.timeout = setTimeout(this.verifyOverflow);
+    this.verifyOverflow();
   }
 
   componentDidUpdate() {
-    this.timeout = setTimeout(this.verifyOverflow);
-  }
-
-  componentWillUnmount() {
-    clearTimeout(this.timeout);
+    this.verifyOverflow();
   }
 
   componentWillReceiveProps = (nextProps) => {


### PR DESCRIPTION
Issue #449

## Test Plan

### tests performed
- verified that old bug ( #346 ) is still here (checkout at 265-focusableview which is last PR for #346):
[![https://gyazo.com/a56c2ee3a4c4e14b82890b3ee1d37160](https://i.gyazo.com/a56c2ee3a4c4e14b82890b3ee1d37160.gif)](https://gyazo.com/a56c2ee3a4c4e14b82890b3ee1d37160)

- remove `setTimeouts`
  - no visible bug:
[![https://gyazo.com/9fb91853f3f145c68c060bd93200ac0f](https://i.gyazo.com/9fb91853f3f145c68c060bd93200ac0f.gif)](https://gyazo.com/9fb91853f3f145c68c060bd93200ac0f)

- log forced `verifyOverflow`s
  - it's called twice (first and third example were the one with the bug visible)

#### cross browser compatibility
tested on IE11 too

### tests not performed (domain coverage)
