### PR TITLE
#455: [FocusableView] optionally debounce focus/blur events (closes #455)

### DIFF
--- a/src/focusable-view/FocusableView.js
+++ b/src/focusable-view/FocusableView.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import cx from 'classnames';
+import debounce from 'lodash/debounce';
 import { props, t, skinnable } from '../utils';
 
 export const Props = {
@@ -9,17 +10,19 @@ export const Props = {
   tabIndex: t.maybe(t.Number),
   component: t.maybe(t.union([t.Function, t.String])),
   ignoreFocus: t.maybe(t.Boolean),
+  debounce: t.maybe(t.Integer),
   className: t.maybe(t.String),
   style: t.maybe(t.Object)
 };
 
 /** A panel that can get focus
- * @param children - FocusableView content. If a function it gets called with the boolean "focused".
+ * @param children - FocusableView content. If a function it gets called with the boolean "focused"
  * @param onFocus - Callback function called on "focus" event
  * @param onBlur - Callback function called on "blur" event
  * @param tabIndex - "tabindex" attribute
  * @param component - Wrapper component for `children`
  * @param ignoreFocus - When `true` the class "focused" is NOT added
+ * @param debounce - Debounce onFocus/onBlur events of x millis
  */
 @skinnable()
 @props(Props, { strict: false })
@@ -32,9 +35,14 @@ export default class FocusableView extends React.Component {
     onBlur: () => {}
   };
 
-  constructor(props) {
-    super(props);
-    this.state = { focused: false };
+  state = { focused: false };
+
+  componentDidMount() {
+    this._mounted = true;
+  }
+
+  componentWillUnmount() {
+    this._mounted = false;
   }
 
   _onFocus = () => {
@@ -47,15 +55,39 @@ export default class FocusableView extends React.Component {
     this.props.onBlur();
   };
 
+  _onFocusBlurEvent = (type) => {
+    const { _mounted, state: { focused } } = this;
+
+    if (!_mounted) {
+      return;
+    }
+
+    if (type === 'blur' && focused) {
+      this._onBlur();
+    } else if (type === 'focus' && !focused) {
+      this._onFocus();
+    }
+  }
+
+  onFocusBlurEventDebounced = debounce(this._onFocusBlurEvent, this.props.debounce)
+
+  onFocusBlurEvent = ({ type }) => (
+    !t.Nil.is(this.props.debounce) ? this.onFocusBlurEventDebounced(type) : this._onFocusBlurEvent(type)
+  )
+
   getLocals() {
-    const { focused } = this.state;
-    const { className, ignoreFocus, ...props } = this.props;
+    const {
+      onFocusBlurEvent,
+      state: { focused },
+      props: { className, ignoreFocus, ...props }
+    } = this;
+
     return {
       ...props,
       focused,
       className: !ignoreFocus ? cx(className, { focused }) : className,
-      onFocus: this._onFocus,
-      onBlur: this._onBlur
+      onFocus: onFocusBlurEvent,
+      onBlur: onFocusBlurEvent
     };
   }
 


### PR DESCRIPTION
Issue #455

## Test Plan

### tests performed
`debounce: undefined` --> no debounce
`debounce: 1000` --> focus/blur events are merged and debounced of 1000ms
- rapidly focus/blur/focus/blur --> onFocus/onBlur never called --> no rerender even without `@pure`

#### cross browser compatibility

### tests not performed (domain coverage)
