### PR TITLE
#468: make TextOverflow optionally lazy (closes #468)

### DIFF
--- a/examples/components/index.js
+++ b/examples/components/index.js
@@ -1,3 +1,4 @@
+import { sortBy } from 'lodash';
 import examplesJSON from 'raw!./examples.json';
 import './styles';
 
@@ -8,7 +9,7 @@ function dynamicRequire(e) {
   return require(`raw!./${path}.example`);
 }
 
-const components = json.components.map(c => ({
+const components = sortBy(json.components, 'title').map(c => ({
   ...c,
   examples: c.examples.map(dynamicRequire)
 }));

--- a/examples/components/text-overflow/Default.example
+++ b/examples/components/text-overflow/Default.example
@@ -17,6 +17,7 @@ const Example = React.createClass({
           style={{ color: 'blue' }}
           label={this.state.text}
           popover={{ position: 'bottom', anchor: 'left' }}
+          lazy
         />
       </button>
     );

--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -41,7 +41,9 @@ export default class TextOverflow extends React.Component {
     }
   };
 
-  reset = () => this.setState({ isOverflowing: false });
+  reset = () => this.setState({
+    isOverflowing: false
+  }, () => this.verifyOverflow({ force: true, reset: true }));
 
   logWarnings = () => {
     warn(() => {
@@ -64,7 +66,7 @@ export default class TextOverflow extends React.Component {
     return null;
   };
 
-  verifyOverflow = (force) => {
+  verifyOverflow = ({ force, reset } = {}) => {
     if ((force || (!this.props.lazy && this.state.isOverflowing === false)) && typeof window !== 'undefined') {
       const text = ReactDOM.findDOMNode(this.refs.text);
       const textWithoutEllipsis = ReactDOM.findDOMNode(this.refs.textWithoutEllipsis);
@@ -76,7 +78,7 @@ export default class TextOverflow extends React.Component {
         const isOverflowing = (textWidth < textWithoutEllipsisWidth);
         if (isOverflowing && !this.state.isOverflowing) {
           this.setState({ isOverflowing: true }, this.logWarnings);
-        } else if (force && this.state.isOverflowing) {
+        } else if (reset && this.state.isOverflowing) {
           this.setState({ isOverflowing: false }, this.logWarnings);
         } else {
           this.logWarnings();
@@ -88,7 +90,7 @@ export default class TextOverflow extends React.Component {
   onMouseEnter = () => {
     this.setState({
       isHovering: true
-    }, () => this.props.lazy && this.verifyOverflow(true));
+    }, () => this.props.lazy && this.verifyOverflow({ force: true }));
   }
 
   onMouseLeave = () => this.setState({ isHovering: false })
@@ -114,7 +116,7 @@ export default class TextOverflow extends React.Component {
     };
     return (
       <div>
-        <ResizeSensor onResize={() => this.verifyOverflow(true)}>
+        <ResizeSensor onResize={() => this.verifyOverflow({ force: true })}>
           <span ref='text' {...events} style={styleText}>{label}</span>
         </ResizeSensor>
         <span ref='textWithoutEllipsis' style={styleTextWithoutEllipsis}>{label}</span>
@@ -135,7 +137,7 @@ export default class TextOverflow extends React.Component {
         ...other,
         popover: {
           content: label,
-          event: !lazy ? 'hover' : undefined,
+          event: 'hover',
           isOpen: lazy ? isHovering : undefined
         },
         style: {

--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -28,11 +28,11 @@ export default class TextOverflow extends React.Component {
   state = { isOverflowing: false };
 
   componentDidMount() {
-    this.verifyOverflow();
+    !this.props.lazy && this.verifyOverflow();
   }
 
   componentWillReceiveProps = (nextProps) => {
-    if (nextProps.label !== this.props.label) {
+    if (!this.props.lazy && nextProps.label !== this.props.label) {
       this.reset();
     }
   };

--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -31,10 +31,6 @@ export default class TextOverflow extends React.Component {
     this.verifyOverflow();
   }
 
-  componentDidUpdate() {
-    this.verifyOverflow();
-  }
-
   componentWillReceiveProps = (nextProps) => {
     if (nextProps.label !== this.props.label) {
       this.reset();

--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -86,7 +86,7 @@ export default class TextOverflow extends React.Component {
   onMouseEnter = () => {
     this.setState({
       isHovering: true
-    }, () => this.props.lazy && this.verifyOverflow({ force: true }));
+    }, () => this.props.lazy && this.verifyOverflow({ force: true, reset: true }));
   }
 
   onMouseLeave = () => this.setState({ isHovering: false })
@@ -118,7 +118,7 @@ export default class TextOverflow extends React.Component {
     const text = <span ref='text' {...events} style={styleText}>{label}</span>;
     return (
       <div>
-        <ResizeSensor onResize={this.onResize}>{text}</ResizeSensor>
+        {lazy ? text : <ResizeSensor onResize={this.onResize}>{text}</ResizeSensor>}
         <span ref='textWithoutEllipsis' style={styleTextWithoutEllipsis}>{label}</span>
       </div>
     );

--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -78,7 +78,7 @@ export default class TextOverflow extends React.Component {
         const isOverflowing = (textWidth < textWithoutEllipsisWidth);
         if (isOverflowing && !this.state.isOverflowing) {
           this.setState({ isOverflowing: true }, this.logWarnings);
-        } else if (reset && this.state.isOverflowing) {
+        } else if (!isOverflowing && reset && this.state.isOverflowing) {
           this.setState({ isOverflowing: false }, this.logWarnings);
         } else {
           this.logWarnings();
@@ -94,6 +94,8 @@ export default class TextOverflow extends React.Component {
   }
 
   onMouseLeave = () => this.setState({ isHovering: false })
+
+  onResize = () => this.verifyOverflow({ force: true, reset: true })
 
   getContent = () => {
     const { label, lazy } = this.props;
@@ -116,11 +118,11 @@ export default class TextOverflow extends React.Component {
       onMouseEnter: this.onMouseEnter,
       onMouseLeave: this.onMouseLeave
     };
+
+    const text = <span ref='text' {...events} style={styleText}>{label}</span>;
     return (
       <div>
-        <ResizeSensor onResize={() => this.verifyOverflow({ force: true })}>
-          <span ref='text' {...events} style={styleText}>{label}</span>
-        </ResizeSensor>
+        <ResizeSensor onResize={this.onResize}>{text}</ResizeSensor>
         <span ref='textWithoutEllipsis' style={styleTextWithoutEllipsis}>{label}</span>
       </div>
     );

--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -108,7 +108,9 @@ export default class TextOverflow extends React.Component {
     const styleTextWithoutEllipsis = {
       position: 'fixed',
       visibility: 'hidden',
-      pointerEvents: 'none'
+      pointerEvents: 'none',
+      top: 0,
+      left: 0
     };
     const events = lazy && {
       onMouseEnter: this.onMouseEnter,

--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -25,10 +25,7 @@ import ResizeSensor from '../resize-sensor/ResizeSensor';
 }, { strict: false })
 export default class TextOverflow extends React.Component {
 
-  constructor(props) {
-    super(props);
-    this.state = { isOverflowing: false };
-  }
+  state = { isOverflowing: false };
 
   componentDidMount() {
     this.verifyOverflow();
@@ -77,9 +74,9 @@ export default class TextOverflow extends React.Component {
         const textWithoutEllipsisWidth = this.getElementWidth(textWithoutEllipsis);
 
         const isOverflowing = (textWidth < textWithoutEllipsisWidth);
-        if (isOverflowing) {
+        if (isOverflowing && !this.state.isOverflowing) {
           this.setState({ isOverflowing: true }, this.logWarnings);
-        } else if (force) {
+        } else if (force && this.state.isOverflowing) {
           this.setState({ isOverflowing: false }, this.logWarnings);
         } else {
           this.logWarnings();

--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -97,7 +97,7 @@ export default class TextOverflow extends React.Component {
   onMouseLeave = () => this.setState({ isHovering: false })
 
   getContent = () => {
-    const { label } = this.props;
+    const { label, lazy } = this.props;
     const styleText = {
       display: 'block',
       whiteSpace: 'nowrap',
@@ -111,7 +111,7 @@ export default class TextOverflow extends React.Component {
       visibility: 'hidden',
       pointerEvents: 'none'
     };
-    const events = {
+    const events = lazy && {
       onMouseEnter: this.onMouseEnter,
       onMouseLeave: this.onMouseLeave
     };
@@ -128,17 +128,18 @@ export default class TextOverflow extends React.Component {
   templateOverflow = () => {
     const {
       state: { isHovering },
-      props: { children, label, style, ...other }
+      props: { children, label, style, lazy, ...other }
     } = this;
 
     if (children) {
-      return children(this.getContent(), isHovering);
+      return children(this.getContent(), lazy ? isHovering : undefined);
     } else {
       const props = {
-        ...omit(other, ['lazy']),
+        ...other,
         popover: {
           content: label,
-          isOpen: isHovering
+          event: !lazy ? 'hover' : undefined,
+          isOpen: lazy ? isHovering : undefined
         },
         style: {
           width: '100%',


### PR DESCRIPTION
Issue #468

## Test Plan

### tests performed
- tested every example with both `lazy: true` and `lazy: false` -> everything worked as expected
- tested on QIA -> ✅ 
- tested on AMS -> ✅ 

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
