### PR TITLE
#470: Add optional delay to TextOverflow (closes #470)

### DIFF
--- a/examples/components/text-overflow/Default.example
+++ b/examples/components/text-overflow/Default.example
@@ -18,6 +18,7 @@ const Example = React.createClass({
           label={this.state.text}
           popover={{ position: 'bottom', anchor: 'left' }}
           lazy
+          delayWhenLazy={1000}
         />
       </button>
     );

--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -19,11 +19,16 @@ import ResizeSensor from '../resize-sensor/ResizeSensor';
    */
   label: t.String,
   lazy: t.maybe(t.Boolean),
+  delayWhenLazy: t.maybe(t.Integer),
   id: t.maybe(t.String),
   className: t.maybe(t.String),
   style: t.maybe(t.Object)
 }, { strict: false })
 export default class TextOverflow extends React.Component {
+
+  static defaultProps = {
+    delayWhenLazy: 100
+  }
 
   state = { isOverflowing: false };
 

--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -98,12 +98,14 @@ export default class TextOverflow extends React.Component {
   )
 
   onMouseEnter = () => {
-    this.setState({
-      isHovering: true
-    }, () => this.props.lazy && this.verifyOverflow({ force: true, reset: true }));
+    if (!this.state.isHovering) {
+      this.setState({
+        isHovering: true
+      }, () => this.props.lazy && this.verifyOverflow({ force: true, reset: true }));
+    }
   }
 
-  onMouseLeave = () => this.setState({ isHovering: false })
+  onMouseLeave = () => this.state.isHovering && this.setState({ isHovering: false })
 
   onResize = () => this.verifyOverflow({ force: true, reset: true })
 

--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import omit from 'lodash/omit';
+import debounce from 'lodash/debounce';
 import { props, t } from '../utils';
 import { warn } from '../utils/log';
 import Popover from '../popover/Popover';
@@ -88,6 +89,20 @@ export default class TextOverflow extends React.Component {
     }
   };
 
+  _onMouseEvent = (type) => {
+    if (type === 'mouseenter') {
+      this.onMouseEnter();
+    } else if (type === 'mouseleave') {
+      this.onMouseLeave();
+    }
+  }
+
+  onMouseEventDebounced = debounce(this._onMouseEvent, this.props.delayWhenLazy)
+
+  onMouseEvent = ({ type }) => (
+    this.props.delayWhenLazy ? this.onMouseEventDebounced(type) : this._onMouseEvent(type)
+  )
+
   onMouseEnter = () => {
     this.setState({
       isHovering: true
@@ -99,7 +114,7 @@ export default class TextOverflow extends React.Component {
   onResize = () => this.verifyOverflow({ force: true, reset: true })
 
   getContent = () => {
-    const { label, lazy } = this.props;
+    const { onMouseEvent, props: { label, lazy } } = this;
     const styleText = {
       display: 'block',
       whiteSpace: 'nowrap',
@@ -116,8 +131,8 @@ export default class TextOverflow extends React.Component {
       left: 0
     };
     const events = lazy && {
-      onMouseEnter: this.onMouseEnter,
-      onMouseLeave: this.onMouseLeave
+      onMouseEnter: onMouseEvent,
+      onMouseLeave: onMouseEvent
     };
 
     const text = <span ref='text' {...events} style={styleText}>{label}</span>;

--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -154,7 +154,7 @@ export default class TextOverflow extends React.Component {
       return children(this.getContent(), lazy ? isHovering : undefined);
     } else {
       const props = {
-        ...other,
+        ...omit(other, ['delayWhenLazy']),
         popover: {
           content: label,
           event: 'hover',

--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -89,13 +89,7 @@ export default class TextOverflow extends React.Component {
     }
   };
 
-  _onMouseEvent = (type) => {
-    if (type === 'mouseenter') {
-      this.onMouseEnter();
-    } else if (type === 'mouseleave') {
-      this.onMouseLeave();
-    }
-  }
+  _onMouseEvent = (type) => (type === 'mouseenter') && this.onMouseEnter()
 
   onMouseEventDebounced = debounce(this._onMouseEvent, this.props.delayWhenLazy)
 
@@ -114,7 +108,7 @@ export default class TextOverflow extends React.Component {
   onResize = () => this.verifyOverflow({ force: true, reset: true })
 
   getContent = () => {
-    const { onMouseEvent, props: { label, lazy } } = this;
+    const { onMouseEvent, onMouseLeave, props: { label, lazy } } = this;
     const styleText = {
       display: 'block',
       whiteSpace: 'nowrap',
@@ -132,7 +126,10 @@ export default class TextOverflow extends React.Component {
     };
     const events = lazy && {
       onMouseEnter: onMouseEvent,
-      onMouseLeave: onMouseEvent
+      onMouseLeave: e => {
+        onMouseEvent(e);
+        onMouseLeave(e);
+      }
     };
 
     const text = <span ref='text' {...events} style={styleText}>{label}</span>;


### PR DESCRIPTION
Issue #470

## Test Plan

### tests performed
[![https://gyazo.com/23513d71544a9aa9ed51be6945c3e605](https://i.gyazo.com/23513d71544a9aa9ed51be6945c3e605.gif)](https://gyazo.com/23513d71544a9aa9ed51be6945c3e605)

PS: tested on QIA too --> the defect (tooltip remaining open) has gone 🎉 

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
