### PR TITLE
#473: [Tooltip] Tooltip doesn't wrap long words (closes #473)

### DIFF
--- a/examples/components/Tooltip/long-word.example
+++ b/examples/components/Tooltip/long-word.example
@@ -1,0 +1,16 @@
+class Example extends React.Component {
+
+  render() {
+    const popover = {
+      position: 'bottom',
+      anchor: 'center',
+      content: 'Thisisthelongestwordyouhaveeverseeninthewholeworld!'
+    }
+    return (
+      <Tooltip popover={popover}>
+        <span>Hover me!</span>
+      </Tooltip>
+    );
+  }
+
+}

--- a/examples/components/examples.json
+++ b/examples/components/examples.json
@@ -69,7 +69,8 @@
       "url": "https://github.com/buildo/react-components/tree/master/src/Tooltip",
       "component": "react-components/__TAG__/src/Tooltip/Tooltip.js",
       "examples": [
-        "react-components/__TAG__/examples/components/Tooltip/default.example"
+        "react-components/__TAG__/examples/components/Tooltip/default.example",
+        "react-components/__TAG__/examples/components/Tooltip/long-word.example"
       ]
     },
     {

--- a/src/Tooltip/tooltip.scss
+++ b/src/Tooltip/tooltip.scss
@@ -14,6 +14,7 @@ $arrow-color: #2C3A40 !default;
 
 .tooltip {
   max-width: 250px;
+  word-wrap: break-word;
   border-radius: $border-radius;
   border: 1px solid;
   z-index: 10000;


### PR DESCRIPTION
Issue #473

## Test Plan

### tests performed
<img width="356" alt="screen shot 2016-06-29 at 13 07 16" src="https://cloud.githubusercontent.com/assets/1838567/16449924/764f6e38-3dfa-11e6-861d-794fe7c5dc5a.png">
