### PR TITLE
#494: [KitchenSink] Readme generator (closes #494)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "deploy-showroom": "git reset && npm run build-showroom && git add ./index.html && git add ./showroom/build && git add ./showroom/components.json && ((git commit -m 'Update gh pages [skip CI]' && git push) || true)",
     "generate-componentsJSON": "node generateComponentsJSON/index.js",
     "generate-readmes": "node generateReadmes/index.js",
+    "generate-all-readmes": "babel-node scripts/generateReadmes.js",
     "release-patch": "./releaseVersion.sh patch",
     "release-breaking-version": "./releaseVersion.sh minor"
   },
@@ -37,6 +38,7 @@
     "bowser": "^1.0.0",
     "classnames": "^2.2.3",
     "css-element-queries": "^0.3.2",
+    "debug": "^2.2.0",
     "fixed-data-table": "^0.4.7",
     "lodash": "^4.6.1",
     "mobile-detect": "^1.2.1",

--- a/scripts/generateReadmes.js
+++ b/scripts/generateReadmes.js
@@ -61,6 +61,41 @@ const walkThroughDirs = (dir, parent, cb) => {
   }
 };
 
+const walkThroughFirstLevelDirs = (dir, cb) => {
+  if (fs.statSync(dir).isDirectory()) {
+    log(`Walking through "${dir}"`);
+
+    const results = fs.readdirSync(dir);
+
+    log(`"${dir}" contains: ${results.join('\n')}`);
+
+    results.forEach(r => {
+      const pathToCheck = path.join(dir, r);
+      log(`Checking path: ${pathToCheck}`);
+      if (fs.statSync(pathToCheck).isDirectory()) {
+        const mainFileName = `${upperFirst(camelCase(r))}.js`;
+
+        const mainFilePath = path.join(dir, r, mainFileName);
+
+        try {
+          if (fs.statSync(mainFilePath).isFile()) {
+            log(`"${r}" contains a main file: "${mainFileName}"!`);
+            cb(pathToCheck, mainFileName);
+          } else {
+            log(`"${r}" does not contain a main file...`);
+          }
+        } catch (e) {
+          log(e);
+        }
+      } else {
+        log(`"${r}" is a file: ignoring!`);
+      }
+    });
+  } else {
+    log(`"${dir}" is not a directory!`);
+  }
+};
+
 const root = process.argv[2] || 'src';
 
-walkThroughDirs(path.resolve(root), '', generateReadMe);
+walkThroughFirstLevelDirs(path.resolve(root), generateReadMe);

--- a/scripts/generateReadmes.js
+++ b/scripts/generateReadmes.js
@@ -4,6 +4,8 @@ import t from 'tcomb';
 import parse from './parse';
 import template from './template';
 import debug from 'debug';
+import upperFirst from 'lodash/upperFirst';
+import camelCase from 'lodash/camelCase';
 
 debug.enable('brc:*');
 const log = debug('brc:generate-readmes');
@@ -17,11 +19,6 @@ const checkDocs = (json, fileName) => {
     throw new Error(`Missing description for file ${fileName}.`);
   }
 
-};
-
-const kebabToPascalCase = value => {
-  const words = value.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
-  return words.join('');
 };
 
 const generateReadMe = (dir, fileName) => {
@@ -50,7 +47,7 @@ const walkThroughDirs = (dir, parent, cb) => {
       .forEach(r => {
         const pathToCheck = path.join(dir, r);
         log(`Checking path: ${pathToCheck}`);
-        if (fs.statSync(pathToCheck).isFile() && r === `${kebabToPascalCase(parent)}.js`) {
+        if (fs.statSync(pathToCheck).isFile() && r === `${upperFirst(camelCase(parent))}.js`) {
           log(`${r} is a file!`);
           cb(dir, r);
         } else if (fs.statSync(pathToCheck).isDirectory()) {

--- a/scripts/generateReadmes.js
+++ b/scripts/generateReadmes.js
@@ -19,6 +19,11 @@ const checkDocs = (json, fileName) => {
 
 };
 
+const kebabToPascalCase = value => {
+  const words = value.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
+  return words.join('');
+};
+
 const generateReadMe = (dir, fileName) => {
   const filePath = path.join(dir, fileName);
   log(`Extracting docs from ${filePath}`);
@@ -36,22 +41,21 @@ const generateReadMe = (dir, fileName) => {
   }
 };
 
-const walkThroughDirs = (dir, cb) => {
+const walkThroughDirs = (dir, parent, cb) => {
   if (fs.statSync(dir).isDirectory()) {
     log(`Walking through ${dir}`);
     fs.readdir(dir, (err, results = []) => {
       log(`${dir} contains: ${results.join('\n')}`);
       results
-      .filter(r => r !== 'index.js' && ['', '.js'].indexOf(path.extname(r)) > -1)
       .forEach(r => {
         const pathToCheck = path.join(dir, r);
         log(`Checking path: ${pathToCheck}`);
-        if (fs.statSync(pathToCheck).isFile() && path.extname(r) === '.js') {
+        if (fs.statSync(pathToCheck).isFile() && r === `${kebabToPascalCase(parent)}.js`) {
           log(`${r} is a file!`);
           cb(dir, r);
         } else if (fs.statSync(pathToCheck).isDirectory()) {
           log(`${r} is a dir!`);
-          walkThroughDirs(path.join(dir, r), cb);
+          walkThroughDirs(path.join(dir, r), r, cb);
         }
       });
     });
@@ -62,4 +66,4 @@ const walkThroughDirs = (dir, cb) => {
 
 const root = process.argv[2] || 'src';
 
-walkThroughDirs(path.resolve(root), generateReadMe);
+walkThroughDirs(path.resolve(root), '', generateReadMe);

--- a/scripts/generateReadmes.js
+++ b/scripts/generateReadmes.js
@@ -77,15 +77,18 @@ const walkThroughFirstLevelDirs = (dir, cb) => {
 
         const mainFilePath = path.join(dir, r, mainFileName);
 
+        let isFile = null;
         try {
-          if (fs.statSync(mainFilePath).isFile()) {
-            log(`"${r}" contains a main file: "${mainFileName}"!`);
-            cb(pathToCheck, mainFileName);
-          } else {
-            log(`"${r}" does not contain a main file...`);
-          }
+          isFile = fs.statSync(mainFilePath).isFile();
         } catch (e) {
           log(e);
+        }
+
+        if (isFile) {
+          log(`"${r}" contains a main file: "${mainFileName}"!`);
+          cb(pathToCheck, mainFileName);
+        } else {
+          log(`"${r}" does not contain a main file...`);
         }
       } else {
         log(`"${r}" is a file: ignoring!`);

--- a/scripts/generateReadmes.js
+++ b/scripts/generateReadmes.js
@@ -1,0 +1,65 @@
+import fs from 'fs';
+import path from 'path';
+import t from 'tcomb';
+import parse from './parse';
+import template from './template';
+import debug from 'debug';
+
+debug.enable('brc:*');
+const log = debug('brc:generate-readmes');
+
+const checkDocs = (json, fileName) => {
+  log('Checking extracted docs have necessary keys...');
+  if (!json.name) {
+    throw new Error(`Missing name for file ${fileName}`);
+  }
+  if (!json.description) {
+    throw new Error(`Missing description for file ${fileName}.`);
+  }
+
+};
+
+const generateReadMe = (dir, fileName) => {
+  const filePath = path.join(dir, fileName);
+  log(`Extracting docs from ${filePath}`);
+  const json = parse(filePath);
+  log(`Extracted: ${t.stringify(json)}`);
+  checkDocs(json, fileName);
+  const readMeContent = template(json);
+  const readMeFilePath = path.join(dir, 'README.md');
+  log(`Writing README.md for file '${fileName}'`);
+  try {
+    fs.writeFileSync(readMeFilePath, readMeContent, 'utf-8');
+    log(`README.md for ${fileName} created at ${readMeFilePath}!`);
+  } catch (e) {
+    log(`Error creating ${fileName} README.md: ${t.stringify(e.getMessage())}`);
+  }
+};
+
+const walkThroughDirs = (dir, cb) => {
+  if (fs.statSync(dir).isDirectory()) {
+    log(`Walking through ${dir}`);
+    fs.readdir(dir, (err, results = []) => {
+      log(`${dir} contains: ${results.join('\n')}`);
+      results
+      .filter(r => r !== 'index.js' && ['', '.js'].indexOf(path.extname(r)) > -1)
+      .forEach(r => {
+        const pathToCheck = path.join(dir, r);
+        log(`Checking path: ${pathToCheck}`);
+        if (fs.statSync(pathToCheck).isFile() && path.extname(r) === '.js') {
+          log(`${r} is a file!`);
+          cb(dir, r);
+        } else if (fs.statSync(pathToCheck).isDirectory()) {
+          log(`${r} is a dir!`);
+          walkThroughDirs(path.join(dir, r), cb);
+        }
+      });
+    });
+  } else {
+    log(`${dir} is not a dir!`);
+  }
+};
+
+const root = process.argv[2] || 'src';
+
+walkThroughDirs(path.resolve(root), generateReadMe);

--- a/scripts/parse.js
+++ b/scripts/parse.js
@@ -1,0 +1,103 @@
+
+import fs from 'fs';
+import t from 'tcomb';
+import find from 'lodash/find';
+import { toObject } from 'tcomb-doc';
+import parseComments from 'get-comments';
+import { parse as parseJSDocs } from 'doctrine';
+
+// (path: t.String) => { description: t.String, tags: Array<Tag> }
+function getComments(path) {
+  const source = fs.readFileSync(path, 'utf8');
+  const comments = parseComments(source, true);
+  const values = comments.map((comment) => {
+    return comment.value;
+  });
+  return parseJSDocs(values.join('\n'), { unwrap: true });
+}
+
+// (comments: t.Object) => { component, props: {} }
+function getDescriptions(comments) {
+  const ret = {
+    component: comments.description || null,
+    props: {}
+  };
+  comments.tags.forEach((tag) => {
+    if (tag.name) {
+      ret.props[tag.name] = tag.description || null;
+    }
+  });
+  return ret;
+}
+
+// (exports: t.Object) => ReactComponent
+function getComponent(defaultExport) {
+  const def = defaultExport['default'] || defaultExport; // eslint-disable-line dot-notation
+  // if (defaultExport['default']) { // eslint-disable-line dot-notation
+  //   defaultExport = defaultExport['default']; // eslint-disable-line dot-notation no-param-reassign
+  // }
+  return def.propTypes ? def : null;
+}
+
+// (component: ReactComponent) => t.String
+function getComponentName(component) {
+  return component.name;
+}
+
+// (component: ReactComponent) => TcombType
+function getPropsType(component) {
+  const propTypes = component.propTypes;
+  const props = {};
+  Object.keys(propTypes).forEach((k) => {
+    if (k !== '__strict__' && k !== '__subtype__') {
+      props[k] = propTypes[k].tcomb;
+    }
+  });
+  if (propTypes.hasOwnProperty('__subtype__')) {
+    return t.refinement(t.struct(props), propTypes.__subtype__.predicate);
+  }
+  return t.struct(props);
+}
+
+// (component: ReactComponent) => t.Object
+function getDefaultProps(component) {
+  return component.defaultProps || {};
+}
+
+// (path: t.String) => { name, description, props }
+export default function parse(path) {
+  if (t.Array.is(path)) {
+    return path.map(parse).filter(Boolean);
+  }
+
+  const component = getComponent(require(path));
+  if (component) {
+    const comments = getComments(path);
+    const descriptions = getDescriptions(comments);
+    const type = toObject(getPropsType(component));
+    const props = type.kind === 'refinement' ? type.type.props : type.props;
+    const defaultProps = getDefaultProps(component);
+    const name = getComponentName(component);
+    const propsSchema = Object.keys(props).reduce((acc, prop) => {
+      const comment = find(comments.tags, (t) => t.name === prop);
+      if (!comment) {
+        throw new Error(`Missing description for prop '${prop}' in '${name}'.`);
+      }
+      if (props.hasOwnProperty(prop)) {
+        if (defaultProps.hasOwnProperty(prop)) {
+          acc[prop].defaultValue = defaultProps[prop];
+        }
+        if (descriptions.props.hasOwnProperty(prop)) {
+          acc[prop].description = descriptions.props[prop];
+        }
+      }
+      return acc;
+    }, props);
+
+    return {
+      name,
+      description: descriptions.component,
+      props: propsSchema
+    };
+  }
+}

--- a/scripts/parse.js
+++ b/scripts/parse.js
@@ -3,6 +3,10 @@ import t from 'tcomb';
 import { toObject } from 'tcomb-doc';
 import parseComments from 'get-comments';
 import { parse as parseJSDocs } from 'doctrine';
+import includes from 'lodash/includes';
+import some from 'lodash/some';
+
+const INVALID_CHARACTERS = ['|'];
 
 // (path: t.String) => { description: t.String, tags: Array<Tag> }
 function getComments(path) {
@@ -85,6 +89,11 @@ export default function parse(path) {
         if (defaultProps.hasOwnProperty(prop)) {
           acc[prop].defaultValue = defaultProps[prop];
         }
+
+        if (some(INVALID_CHARACTERS, c => includes(descriptions.props[prop], c))) {
+          throw new Error(`Description for prop '${prop}' in '${name}' has one or more invalid characters!`);
+        }
+
         acc[prop].description = descriptions.props[prop];
       }
       return acc;

--- a/scripts/template.js
+++ b/scripts/template.js
@@ -1,20 +1,28 @@
 import t from 'tcomb';
-const buildPropsTableRows = (props) =>
+const buildPropsTableRows = (props) => (
   Object.keys(props).map((key) => {
     const prop = props[key];
-    return `| ${key} | ${prop.name} | ${t.stringify(prop.defaultValue || '')} | ${prop.description} |`;
-  }).join('\n');
+
+    const name = key;
+    const type = prop.kind === 'enums' ?
+      JSON.stringify(Object.keys(prop.map)) :
+      prop.name;
+    const defaultValue = typeof prop.defaultValue !== 'undefined' ? prop.defaultValue : '';
+    const description = prop.description;
+
+    return `| ${name} | ${type} | ${t.stringify(defaultValue)} | ${description} |`;
+  }).join('\n')
+);
 
 
 export default function template(data) {
-  return (`
-# ${data.name}
+  return (
+`# ${data.name}
 
 ## ${data.description}
 
 |Name|Type|Default|Description|
 |----|----|-------|-----------|
-${buildPropsTableRows(data.props)}
-
-`);
+${buildPropsTableRows(data.props)}`
+);
 }

--- a/scripts/template.js
+++ b/scripts/template.js
@@ -1,0 +1,20 @@
+import t from 'tcomb';
+const buildPropsTableRows = (props) =>
+  Object.keys(props).map((key) => {
+    const prop = props[key];
+    return `| ${key} | ${prop.name} | ${t.stringify(prop.defaultValue || '')} | ${prop.description} |`;
+  }).join('\n');
+
+
+export default function template(data) {
+  return (`
+# ${data.name}
+
+## ${data.description}
+
+|Name|Type|Default|Description|
+|----|----|-------|-----------|
+${buildPropsTableRows(data.props)}
+
+`);
+}

--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -18,7 +18,7 @@ const defaultDividerProps = {
 };
 
 /** A simple component used to visually divide UI elements
- * @param orientation - vertical | horizontal
+ * @param orientation - vertical - horizontal
  * @param size - size of margins
  */
 @pure

--- a/src/DropdownMenu/DropdownMenu.js
+++ b/src/DropdownMenu/DropdownMenu.js
@@ -28,7 +28,7 @@ export const Props = {
  * @param onOpen - called when menu is open
  * @param onClose - called when menu is closed
  * @param dismissOnClickOut - whether the menu should be closed when clicking outside the dropdown
- * @param size - small | medium | large
+ * @param size - small - medium - large
  * @param maxHeight - menu button max-height
  */
 @pure

--- a/src/Panel/Panel.js
+++ b/src/Panel/Panel.js
@@ -31,14 +31,14 @@ export const Props = {
 };
 
 /** A simple panel with header. It can be collapsable or not, docked or floating.
- * @param type - docked-top | docked-left | docked-right | docked-bottom | floating
+ * @param type - docked-top - docked-left - docked-right - docked-bottom - floating
  * @param header - header props (collapse, content, title, menu)
  * @param loading - whether it's loading or not
  * @param dark - true if it should use dark theme
  * @param softLoading - soft loading
  * @param softLoadingDelay - soft loading delay
  * @param children - panel content
- * @param clearMargin: top | left | right | bottom
+ * @param clearMargin: top - left - right - bottom
  */
 @pure
 @skinnable()

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -6,8 +6,8 @@ import Popover from '../popover/Popover';
 /** Tooltip that appears when the mouse is over an element
  * @param children - the element over which the tooltip is shown
  * @param popover - popover props
- * @param type - light | dark
- * @param size - small | big
+ * @param type - light - dark
+ * @param size - small - big
  */
 @pure
 @skinnable()

--- a/src/dropdown/Dropdown.js
+++ b/src/dropdown/Dropdown.js
@@ -31,7 +31,7 @@ const PropTypes = {
  * @param valueLink - defines actions to be taken when a particular value is selected
  * @param onChange - called when value is changed
  * @param options - available options
- * @param size - medium | small
+ * @param size - medium - small
  * @param disabled - true if disabled
  * @param searchable - true if it should be possible to search the desired value by writing into the dropdown
  * @param clearable - true if it should be possible to reset the selected value

--- a/src/kitchen-sink/KitchenSink.js
+++ b/src/kitchen-sink/KitchenSink.js
@@ -5,7 +5,21 @@ import Sidebar from './sidebar/Sidebar';
 import Content from './content/Content';
 import Component from './content/Component';
 
-export default class KitchenSink extends React.Component {
+/** React component to generate a nice kitchen-sink
+ * @param componentId - selected component page
+ * @param contentId - selected content page
+ * @param sectionId - selected section in sidebar
+ * @param sections - list of sidebar sections,
+ * @param openSections - list of expanded sections in sidebar
+ * @param components - list of components pages
+ * @param onSelectItem - called when user selects an item
+ * @param onToggleSection - called when user click on a section
+ * @param scope - object with variables needed in the components examples
+ * @param iso - wheter the kitchen-sink render examples in a fake isomorphic environment
+ * @param header - renderable node used as header in component page
+ * @param footer - renderable node used as footer in component page
+ * @param loading - wheter it's loading or not
+ */
 
 @props({
   componentId: t.maybe(t.String),

--- a/src/kitchen-sink/KitchenSink.js
+++ b/src/kitchen-sink/KitchenSink.js
@@ -68,8 +68,6 @@ export default class KitchenSink extends React.Component {
   render() {
     const {
       props: {
-        componentId,
-        contentId,
         sections,
         openSections,
         onSelectItem,
@@ -80,7 +78,7 @@ export default class KitchenSink extends React.Component {
 
     return (
       <div className='kitchen-sink'>
-        <Sidebar {...{ sections, openSections, onToggleSection, componentId, contentId, onSelectItem, loading }} >
+        <Sidebar {...{ sections, openSections, onToggleSection, onSelectItem, loading }} >
           {!loading && this.getChildren()}
         </Sidebar>
       </div>

--- a/src/kitchen-sink/KitchenSink.js
+++ b/src/kitchen-sink/KitchenSink.js
@@ -1,26 +1,28 @@
 import React from 'react';
 import find from 'lodash/find';
+import { props, t } from '../utils';
 import Sidebar from './sidebar/Sidebar';
 import Content from './content/Content';
 import Component from './content/Component';
 
 export default class KitchenSink extends React.Component {
 
-  static propTypes = {
-    componentId: React.PropTypes.string,
-    contentId: React.PropTypes.string,
-    sectionId: React.PropTypes.string,
-    sections: React.PropTypes.array.isRequired,
-    openSections: React.PropTypes.array,
-    components: React.PropTypes.array,
-    onSelectItem: React.PropTypes.func.isRequired,
-    onToggleSection: React.PropTypes.func.isRequired,
-    scope: React.PropTypes.object,
-    iso: React.PropTypes.bool,
-    header: React.PropTypes.node,
-    footer: React.PropTypes.node,
-    loading: React.PropTypes.bool
-  };
+@props({
+  componentId: t.maybe(t.String),
+  contentId: t.maybe(t.String),
+  sectionId: t.maybe(t.String),
+  sections: t.Array,
+  openSections: t.maybe(t.Array),
+  components: t.maybe(t.Array),
+  onSelectItem: t.Function,
+  onToggleSection: t.Function,
+  scope: t.maybe(t.Object),
+  iso: t.maybe(t.Boolean),
+  header: t.maybe(t.ReactChildren),
+  footer: t.maybe(t.ReactChildren),
+  loading: t.maybe(t.Boolean)
+})
+export default class KitchenSink extends React.Component {
 
   static defaultProps = {
     openSections: []

--- a/src/kitchen-sink/content/Component.js
+++ b/src/kitchen-sink/content/Component.js
@@ -1,14 +1,14 @@
 import React from 'react';
+import { props, t } from '../../utils';
 import LoadingSpinner from '../../loading-spinner';
 import ExampleCard from './ExampleCard';
 
+@props({
+  iso: t.maybe(t.Boolean),
+  scope: t.Object,
+  component: t.maybe(t.Object)
+})
 export default class Component extends React.Component {
-
-  static propTypes = {
-    iso: React.PropTypes.bool,
-    scope: React.PropTypes.object.isRequired,
-    component: React.PropTypes.object
-  };
 
   getLoadingSpinner() {
     return (

--- a/src/kitchen-sink/content/Component.js
+++ b/src/kitchen-sink/content/Component.js
@@ -6,7 +6,9 @@ import ExampleCard from './ExampleCard';
 @props({
   iso: t.maybe(t.Boolean),
   scope: t.Object,
-  component: t.maybe(t.Object)
+  component: t.maybe(t.Object),
+  header: t.maybe(t.ReactChildren),
+  footer: t.maybe(t.ReactChildren)
 })
 export default class Component extends React.Component {
 

--- a/src/kitchen-sink/content/Content.js
+++ b/src/kitchen-sink/content/Content.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import Markdown from 'react-remarkable';
+import { props, t } from '../../utils';
 
+@props({
+  content: t.struct({
+    content: t.String
+  })
+})
 export default class Content extends React.Component {
-
-  static propTypes = {
-    content: React.PropTypes.shape({
-      content: React.PropTypes.string.isRequired
-    }).isRequired
-  };
 
   render() {
     return (

--- a/src/kitchen-sink/content/ExampleCard.js
+++ b/src/kitchen-sink/content/ExampleCard.js
@@ -1,13 +1,13 @@
 import React from 'react';
+import { props, t } from '../../utils';
 import LiveDemo from './LiveDemo';
 
+@props({
+  iso: t.maybe(t.Boolean),
+  scope: t.Object,
+  codeText: t.String
+})
 export default class ExampleCard extends React.Component {
-
-  static propTypes = {
-    iso: React.PropTypes.bool,
-    scope: React.PropTypes.object.isRequired,
-    codeText: React.PropTypes.string.isRequired
-  };
 
   render() {
     const { scope, codeText, iso } = this.props;

--- a/src/kitchen-sink/content/LiveDemo.js
+++ b/src/kitchen-sink/content/LiveDemo.js
@@ -1,19 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactDOMServer from 'react-dom/server';
-import Playground from 'component-playground';
+import { props, t } from '../../utils';
 import MoreOrLess from '../../more-or-less/MoreOrLess';
 
 const footer = '\n__render(Example);';
 const footerISO = '\n__renderISO(Example);';
 
+@props({
+  iso: t.maybe(t.Boolean),
+  scope: t.Object,
+  codeText: t.String
+})
 export default class LiveDemo extends React.Component {
-
-  static propTypes = {
-    iso: React.PropTypes.bool,
-    scope: React.PropTypes.object.isRequired,
-    codeText: React.PropTypes.string.isRequired
-  };
 
   constructor(props) {
     super(props);

--- a/src/kitchen-sink/content/LiveDemo.js
+++ b/src/kitchen-sink/content/LiveDemo.js
@@ -4,6 +4,10 @@ import ReactDOMServer from 'react-dom/server';
 import { props, t } from '../../utils';
 import MoreOrLess from '../../more-or-less/MoreOrLess';
 
+const Playground = typeof window !== 'undefined' ?
+  require('component-playground').default :
+  null;
+
 const footer = '\n__render(Example);';
 const footerISO = '\n__renderISO(Example);';
 

--- a/src/kitchen-sink/sidebar/Item.js
+++ b/src/kitchen-sink/sidebar/Item.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import cx from 'classnames';
+import { props, t } from '../../utils';
 
+@props({
+  sectionId: t.String,
+  id: t.String,
+  title: t.String,
+  active: t.Boolean,
+  onClick: t.Function
+})
 export default class Item extends React.Component {
-
-  static propTypes = {
-    sectionId: React.PropTypes.string.isRequired,
-    id: React.PropTypes.string.isRequired,
-    title: React.PropTypes.string.isRequired,
-    active: React.PropTypes.bool.isRequired,
-    onClick: React.PropTypes.func.isRequired
-  };
 
   onClick = () => this.props.onClick(this.props.sectionId, this.props.id);
 

--- a/src/kitchen-sink/sidebar/Sidebar.js
+++ b/src/kitchen-sink/sidebar/Sidebar.js
@@ -1,8 +1,17 @@
 import React from 'react';
 import ReactSidebar from 'react-sidebar';
+import { props, t } from '../../utils';
 import LoadingSpinner from '../../loading-spinner';
 import SidebarContent from './SidebarContent';
 
+@props({
+  children: t.ReactChildren,
+  sections: t.Array,
+  openSections: t.Array,
+  onSelectItem: t.Function,
+  onToggleSection: t.maybe(t.Function),
+  loading: t.maybe(t.Boolean)
+})
 export default class Sidebar extends React.Component {
 
   static propTypes = {

--- a/src/kitchen-sink/sidebar/SidebarContent.js
+++ b/src/kitchen-sink/sidebar/SidebarContent.js
@@ -20,7 +20,14 @@ export default class SidebarContent extends React.Component {
   render() {
     const { sections, onSelectItem } = this.props;
     const getItems = (sectionId, items) => items.map(({ id, ...item }) =>
-      <Item {...item} id={id} onClick={onSelectItem} sectionId={sectionId} indent active={this.isActive(id)} key={id} />
+      <Item
+        title={item.title}
+        id={id}
+        onClick={onSelectItem}
+        sectionId={sectionId}
+        active={this.isActive(id)}
+        key={id}
+      />
     );
 
     const getSections = (sections) => sections.map(({ id, components, contents, title }) => (

--- a/src/kitchen-sink/sidebar/SidebarContent.js
+++ b/src/kitchen-sink/sidebar/SidebarContent.js
@@ -1,15 +1,15 @@
 import React from 'react';
+import { props, t } from '../../utils';
 import Item from './Item';
 import CollapsableSection from '../../collapsable-section/CollapsableSection';
 
+@props({
+  sections: t.maybe(t.Array),
+  openSections: t.Array,
+  onSelectItem: t.Function,
+  onToggleSection: t.maybe(t.Function)
+})
 export default class SidebarContent extends React.Component {
-
-  static propTypes = {
-    sections: React.PropTypes.array,
-    openSections: React.PropTypes.array.isRequired,
-    onSelectItem: React.PropTypes.func.isRequired,
-    onToggleSection: React.PropTypes.func
-  };
 
   isActive = (id) => false && id;
 

--- a/src/table/Table.js
+++ b/src/table/Table.js
@@ -78,7 +78,7 @@ const Props = t.subtype(t.struct({
  * @param selectedRows - selected rows
  * @param onRowSelect - called when a row is selected
  * @param onRowsSelect - called when multiple rows are selected
- * @param selectionType - none | sigle | multi
+ * @param selectionType - none - sigle - multi
  * @param onColumnResizeEndCallback - called after a column has been resized
  * @param isColumnResizing - whether a column is currently being resized
  * @param columns - list of columns

--- a/src/time-picker/TimePicker.js
+++ b/src/time-picker/TimePicker.js
@@ -34,34 +34,12 @@ const Time = t.struct({
 const isValidHoursInTimeFormat = (hours, timeFormat) => timeFormat === H24 ? Hour.is(hours) : Hour12.is(hours);
 
 const Props = t.refinement(t.struct({
-  /**
-  * onChange handler it will return an object
-  */
   onChange: t.Function,
-  /**
-   * Value provided as input. Have to be passed in 24h format.
-   * Es: { hours: 10, minutes: 30 }
-   */
   value: t.maybe(Time),
-  /**
-   * Minimum value. Have to be passed in 24h format. Default [00:00]
-   */
   minTime: t.maybe(Time),
-  /**
-   * Maximum value. Have to be passed in 24h format. Default [23:59]
-   */
   maxTime: t.maybe(Time),
-  /**
-   * Field placeholder, displayed when there's no value. Default[--:--]
-   */
   placeholder: t.maybe(t.String),
-  /**
-   * format in which options are displayed. Default [24H].
-   */
   timeFormat: t.maybe(TimeFormat),
-  /**
-   * Enable the search feature
-   */
   searchable: t.Boolean,
   id: t.maybe(t.String),
   className: t.maybe(t.String),

--- a/src/time-picker/TimePicker.js
+++ b/src/time-picker/TimePicker.js
@@ -181,7 +181,7 @@ export const makeFilterOptions = ({ minTime, maxTime, timeFormat }) => (_, input
  * @param minTime - minimum value. Have to be passed in 24h format. Default [00:00]
  * @param maxTime - maximum value. Have to be passed in 24h format. Default [23:59]
  * @param placeholder - field placeholder, displayed when there's no value. Default[--:--]
- * @param timeFormat - format in which options are displayed (12h|24h)
+ * @param timeFormat - format in which options are displayed (12h, 24h)
  * @param searchable - enable the search feature
  */
 @skinnable()

--- a/src/toaster/Toaster.js
+++ b/src/toaster/Toaster.js
@@ -14,7 +14,7 @@ import TransitionWrapper from '../transition-wrapper/TransitionWrapper';
  * @param transitionStyles - object with style for each transition event (used by `TransitionWrapper`)
  * @param transitionEnterTimeout - duration of enter transition in milliseconds (used by `TransitionWrapper`)
  * @param transitionLeaveTimeout - duration of leave transition in milliseconds (used by `TransitionWrapper`)
- * @param position - top-left | top-right | bottom-left | bottom-right
+ * @param position - top-left - top-right - bottom-left - bottom-right
  */
 @props({
   children: t.ReactChildren,


### PR DESCRIPTION
Issue #494

I created a new version of `generateReadme.js` file following the approach given by `tcomb-react` to extract component documentation.
The script is testable by:
```shell
# to generate README.md file for each component
$ npm run generate-all-readmes 
```

The npm task doesn't work as it is cause the components don't have the correct documentation structure to be parsed, cause I've defined strict rules in order to be sure every component is documented rightly, and the rules are:
- component must have a name (now it's extracted from the the class name)
- component must have a description (even a simple one, but it's required from my pov)
- each component props must be documented

You can add comments 
```js
/**
 * Component description here
 * @param prop1 - this is the prop 1 description 
 * @param prop2 - this is the prop 2 description
 * ...
 */
```
to a component and test with 
```shell
# to generate README(s).md for a specific component
$ babel-node scripts/generateReadme.js src/${componentfolder} 
```

**N.B.** the file is full of log for debug purpose.