### PR TITLE
#538: Broken props table in READMEs (closes #538)

### DIFF
--- a/scripts/template.js
+++ b/scripts/template.js
@@ -15,7 +15,7 @@ const formatType = prop => {
 };
 
 const cleanInvalidCharacters = string => {
-  return string.replace(/\|/g, '&#124;');
+  return string.replace(/\|/g, '&#124;').replace(/\n/g, ' ');
 };
 
 const buildPropsTableRows = (props) => (


### PR DESCRIPTION
Issue #538

## Test Plan

### tests performed
`overlay` default value in `Modal` README doesn't break the layout anymore

![image](https://cloud.githubusercontent.com/assets/925635/18167395/abc92076-7050-11e6-991e-dbbacaa2d2a3.png)
