### PR TITLE
#608: Remove dot sh from npm ignore (closes #608)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,4 +5,3 @@ npm-debug.log
 test
 karma*
 .eslintrc
-*.sh


### PR DESCRIPTION
Issue #608

## Test Plan

- it should be installable now (try `npm ${LOCAL_FORLDER}`)