### PR TITLE
#605: Popover: support delay on mouse events (closes #605)

### DIFF
--- a/src/kitchen-sink/sidebar/SidebarContent.js
+++ b/src/kitchen-sink/sidebar/SidebarContent.js
@@ -49,6 +49,7 @@ export default class SidebarContent extends React.Component {
           {...{ title, id, sectionId }}
           onClick={this.props.onSelectItem}
           active={this.isActive(id)}
+          key={sectionId}
         />
       );
     }

--- a/src/popover/examples/hover.js
+++ b/src/popover/examples/hover.js
@@ -23,7 +23,8 @@ class Example extends React.Component {
       position: 'top',
       anchor: 'start',
       event: 'hover',
-      className: 'baloon'
+      className: 'baloon',
+      delay: { whenOpen: 100 }
     };
 
     return (


### PR DESCRIPTION
Issue #605

## Test Plan

### tests performed
- pass `delay: undefined`
  - opens immediately
  - closes immediately
  - debounced event cb is not called (calling directly `_onMouseEvent`)
- pass `delay: 1000`
  - opens after 1s
  - closes after 1s
- pass `delay: { whenOpen: 100 }` (that I left as new default in the hover example)
  - opens immediately
  - closes after 100ms (enough to move the cursor to the popover before it closes)


### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
