### PR TITLE
#623: Dropdown: menu-background should be applied also to option (closes #623)

### DIFF
--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -165,6 +165,7 @@ $height-small: 30px !default;
       font-size: 15px;
       font-weight: 400;
       color: $option-color;
+      background: $menu-background;
 
       &:hover, &.is-focused {
         color: $option-color-hover;


### PR DESCRIPTION
Issue #623

## Test Plan

### tests performed
- try to change `menu-background` variable to `red` or anything
- `npm start && open http://localhost:8080http://localhost:8080/#/sections/components/component/dropdown?`
- menu should be `red` (or anything)

![image](https://cloud.githubusercontent.com/assets/3280300/18749012/33edd76e-80d5-11e6-819e-b387a4f12dd9.png)
