### PR TITLE
#612: TimePicker selection, keyboard selection and focus (closes #612)

### DIFF
--- a/test/components/BackgroundDimmer.test.js
+++ b/test/components/BackgroundDimmer.test.js
@@ -53,6 +53,7 @@ describe('BackgroundDimmer', () => {
 
     it('uses default props', () => {
       const dimmer = new BackgroundDimmer({
+        ...BackgroundDimmer.defaultProps,
         children: content
       });
       const locals = dimmer.getLocals();

--- a/test/components/Badge.test.js
+++ b/test/components/Badge.test.js
@@ -16,6 +16,7 @@ describe('Badge', () => {
 
     it('computes className', () => {
       const badge = new Badge({
+        ...Badge.defaultProps,
         label: 42,
         className: 'awesome-class'
       });
@@ -27,6 +28,7 @@ describe('Badge', () => {
 
     it('computes className when active', () => {
       const badge = new Badge({
+        ...Badge.defaultProps,
         active: true,
         label: 42,
         className: 'awesome-class'

--- a/test/components/Dropdown.test.js
+++ b/test/components/Dropdown.test.js
@@ -8,6 +8,7 @@ import Dropdown from '../../src/dropdown';
 jest.mock('react-dom');
 
 const exampleProps = {
+  ...Dropdown.defaultProps,
   id: '12345',
   className: 'fancy-class-name',
   style: { margin: 10, position: 'relative' },
@@ -47,6 +48,7 @@ describe('Dropdown', () => {
 
     it('computes value from a string', () => {
       const dropdown = new Dropdown({
+        ...Dropdown.defaultProps,
         value: 'test',
         options: [
           { value: 'test', label: 'Test' },
@@ -61,6 +63,7 @@ describe('Dropdown', () => {
 
     it('computes value from a number', () => {
       const dropdown = new Dropdown({
+        ...Dropdown.defaultProps,
         value: 2,
         options: [
           { value: 0, label: 'Test' },

--- a/test/components/Meter.test.js
+++ b/test/components/Meter.test.js
@@ -4,6 +4,7 @@ import renderer from 'react-test-renderer';
 import Meter from '../../src/meter';
 
 const exampleProps = {
+  ...Meter.defaultProps,
   id: '12345',
   className: 'fancy-class-name',
   style: { margin: 10, position: 'relative' },
@@ -66,6 +67,7 @@ describe('Meter', () => {
 
     it('computes basisSize with custom min and max', ()  => {
       const meter = new Meter({
+        ...Meter.defaultProps,
         value: 150,
         min: 100,
         max: 200,
@@ -77,6 +79,7 @@ describe('Meter', () => {
 
     it('computes basisSize for custom negative min', ()  => {
       const meter = new Meter({
+        ...Meter.defaultProps,
         value: 0,
         min: -100,
         max: 100,
@@ -88,6 +91,7 @@ describe('Meter', () => {
 
     it('computes background color for filling', ()  => {
       const meter = new Meter({
+        ...Meter.defaultProps,
         value: 60,
         ranges: [
           { startValue: 50, endValue: 80, fillingColor: 'yellow' }
@@ -100,6 +104,7 @@ describe('Meter', () => {
 
     it('defaults to the base color as background color if there\'s no matching range', ()  => {
       const meter = new Meter({
+        ...Meter.defaultProps,
         value: 20,
         baseFillingColor: '#ccc',
         ranges: [
@@ -113,6 +118,7 @@ describe('Meter', () => {
 
     it('doesn\'t define a background color if there\'s no matching range and no default is given', ()  => {
       const meter = new Meter({
+        ...Meter.defaultProps,
         value: 20,
         ranges: [
           { startValue: 50, endValue: 80, fillingColor: 'yellow' }
@@ -125,6 +131,7 @@ describe('Meter', () => {
 
     it('defaults to base color as bar background color should if there\'s no matching range', ()  => {
       const meter = new Meter({
+        ...Meter.defaultProps,
         value: 20,
         baseBackroundColor: '#ccc',
         ranges: [
@@ -138,6 +145,7 @@ describe('Meter', () => {
 
     it('doesn\'t define a bar background color if there\'s no matching range and no default is given', ()  => {
       const meter = new Meter({
+        ...Meter.defaultProps,
         value: 20,
         ranges: [
           { startValue: 50, endValue: 80, backgroundColor: 'yellow' }

--- a/test/components/MoreOrLess.test.js
+++ b/test/components/MoreOrLess.test.js
@@ -4,6 +4,7 @@ import renderer from 'react-test-renderer';
 import MoreOrLess from '../../src/more-or-less';
 
 const exampleProps = {
+  ...MoreOrLess.defaultProps,
   children: 'content',
   className: 'fancy-class-name',
   icons: {
@@ -61,4 +62,3 @@ describe('MoreOrLess', () => {
   });
 
 });
-

--- a/test/components/StatefulButton.test.js
+++ b/test/components/StatefulButton.test.js
@@ -15,6 +15,7 @@ function timeoutPromise(millis) {
 }
 
 const exampleProps = {
+  ...StatefulButton.defaultProps,
   label: 'BeautifulButton',
   onClick: timeoutPromise.bind(this, 5),
   baseState: 'ready',

--- a/test/components/TimePicker.test.js
+++ b/test/components/TimePicker.test.js
@@ -10,6 +10,7 @@ import TimePicker, {
 jest.mock('react-dom');
 
 const exampleProps = {
+  ...TimePicker.defaultProps,
   id: '12345',
   className: 'fancy-class-name',
   placeholder: '--:--',
@@ -44,6 +45,7 @@ describe('TimePicker', () => {
 
     it('passes value properly formatted when H24', () => {
       const timePicker = new TimePicker({
+        ...TimePicker.defaultProps,
         value: { hours: 15, minutes: 33 }
       });
       const { value } = timePicker.getLocals();
@@ -52,6 +54,7 @@ describe('TimePicker', () => {
 
     it('passes value properly formatted when H12', () => {
       const timePicker = new TimePicker({
+        ...TimePicker.defaultProps,
         value: { hours: 15, minutes: 33 },
         timeFormat: H12
       });
@@ -60,7 +63,7 @@ describe('TimePicker', () => {
     });
 
     it('passes an undefined value when value prop is undefined', () => {
-      const timePicker = new TimePicker({});
+      const timePicker = new TimePicker({ ...TimePicker.defaultProps });
       const { value } = timePicker.getLocals();
       expect(value).toBeUndefined();
     });

--- a/test/components/TimePicker.test.js
+++ b/test/components/TimePicker.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import TimePicker, {
-  parseInTimeFormat, H24, H12, toOption, filterTime, createTimeList, makeFilterOptions, inputError
+  parseInTimeFormat, H24, H12, toOption, filterTime, createTimeList, makeOptions, inputError
 } from '../../src/time-picker/TimePicker';
 
 // Because of this bug: https://github.com/facebook/react/issues/7386
@@ -240,21 +240,19 @@ describe('TimePicker', () => {
 
   });
 
-  describe('makeFilterOptions', () => {
+  describe('makeOptions', () => {
 
     it('computes options based on min/max for 24H time', () => {
-      const filterOptions = makeFilterOptions({ timeFormat: H24, minTime: { hours: 5, minutes: 10 }, maxTime: { hours: 7, minutes: 20 } });
       const inputStr = '';
-      const results = filterOptions([], inputStr);
+      const results = makeOptions({ timeFormat: H24, minTime: { hours: 5, minutes: 10 }, maxTime: { hours: 7, minutes: 20 } }, inputStr);
       expect(results.length).toBe(4);
       expect(results[0]).toEqual({ label: '05:30', value: '05:30' });
       expect(results[3]).toEqual({ label: '07:00', value: '07:00' });
     });
 
     it('computes options based on min/max for 12H time', () => {
-      const filterOptions = makeFilterOptions({ timeFormat: H12, minTime: { hours: 5, minutes: 10 }, maxTime: { hours: 7, minutes: 20 } });
       const inputStr = '';
-      const results = filterOptions([], inputStr);
+      const results = makeOptions({ timeFormat: H12, minTime: { hours: 5, minutes: 10 }, maxTime: { hours: 7, minutes: 20 } }, inputStr);
       expect(results.length).toBe(4);
       expect(results[0]).toEqual({ label: '05:30 am', value: '05:30' });
       expect(results[3]).toEqual({ label: '07:00 am', value: '07:00' });

--- a/test/components/__snapshots__/BackgroundDimmer.test.js.snap
+++ b/test/components/__snapshots__/BackgroundDimmer.test.js.snap
@@ -5,10 +5,10 @@ Object {
     "column": true,
     "onClick": [Function anonymous],
     "style": Object {
-      "height": undefined,
-      "maxHeight": undefined,
-      "maxWidth": undefined,
-      "width": undefined
+      "height": "auto",
+      "maxHeight": "90%",
+      "maxWidth": "90%",
+      "width": "auto"
     }
   },
   "children": <div
@@ -29,20 +29,20 @@ Object {
       "position": "fixed",
       "right": 0,
       "top": 0,
-      "zIndex": NaN
+      "zIndex": 100000
     },
     "vAlignContent": "center"
   },
   "overlayProps": Object {
     "style": Object {
-      "backgroundColor": undefined,
+      "backgroundColor": "black",
       "bottom": 0,
       "left": 0,
-      "opacity": "undefined",
+      "opacity": "0.5",
       "position": "fixed",
       "right": 0,
       "top": 0,
-      "zIndex": undefined
+      "zIndex": 99999
     }
   },
   "stopPropagation": [Function anonymous]


### PR DESCRIPTION
Issue #612

## Test Plan

### tests performed
- Time picker options are computed correctly and refreshed whenever input changes
- Can navigate through options with arrow keys ✅ 

[![https://gyazo.com/7250d349efab16bc86a488990a4500dc](https://i.gyazo.com/7250d349efab16bc86a488990a4500dc.gif)](https://gyazo.com/7250d349efab16bc86a488990a4500dc)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
