### PR TITLE
#635: Dropdown: add sass variable $option-background-selected (closes #635)

### DIFF
--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -24,7 +24,9 @@ $menu-background: $brc-white !default;
 $menu-border-color: $brc-silver !default;
 $option-color: rgba($brc-darkGrey, .5) !default;
 $option-color-hover: $brc-darkGrey !default;
+$option-color-selected: $option-color !default;
 $option-background-hover: rgba($brc-azure, .15) !default;
+$option-background-selected: $menu-background !default;
 $multiple-value-color: #007eff !default;
 $multiple-value-border-color: $multiple-value-color !default;
 $multiple-value-background-color: #daecf6 !default;
@@ -166,6 +168,11 @@ $height-small: 30px !default;
       font-weight: 400;
       color: $option-color;
       background: $menu-background;
+
+      &.is-selected {
+        background: $option-background-selected;
+        color: $option-color-selected;
+      }
 
       &:hover,
       &.is-focused {

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -176,7 +176,7 @@ $height-small: 30px !default;
 
       &:hover,
       &.is-focused {
-        background-color: $option-background-hover;
+        background: $option-background-hover;
         color: $option-color-hover;
       }
     }


### PR DESCRIPTION
Issue #635

## Test Plan

### tests performed
- set `option-background-selected` to "green"
- set `option-color-selected`  "red"

-->
[![https://gyazo.com/b61cf1b470971dfa28bef31b3bc56420](https://i.gyazo.com/b61cf1b470971dfa28bef31b3bc56420.gif)](https://gyazo.com/b61cf1b470971dfa28bef31b3bc56420)

PS: I also tested that option-background-hover still works:
- set `$option-background-hover` to "black"
  - option turns black when hovered

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
