### PR TITLE
#649: LoadingSpinner should enforce box-sizing: border-box (closes #649)

### DIFF
--- a/src/loading-spinner/loadingSpinner.scss
+++ b/src/loading-spinner/loadingSpinner.scss
@@ -33,6 +33,7 @@ $thickness: .1em;
       border-left-color: transparent;
       -webkit-animation: spin $period infinite $easing;
       animation: spin $period infinite $easing;
+      box-sizing: border-box;
 
       &::after {
         content: '';


### PR DESCRIPTION
Issue #649

## Test Plan

- ui shouldn't break in project without buildo/normalize (i.e. global `box-sizing: border-box`)