### PR TITLE
#663: TimePicker missing "is-selected" class (closes #663)

### DIFF
--- a/src/time-picker/TimePicker.js
+++ b/src/time-picker/TimePicker.js
@@ -189,9 +189,7 @@ export default class TimePicker extends React.Component {
       ...props
     } = this.props;
 
-    const value = userValue ? toOption({
-      ...userValue, timeFormat
-    }) : undefined;
+    const value = userValue ? formatTime24(userValue) : undefined;
 
     return {
       ...props,

--- a/test/components/TimePicker.test.js
+++ b/test/components/TimePicker.test.js
@@ -43,23 +43,13 @@ describe('TimePicker', () => {
       expect(className).toContain('fancy-class-name');
     });
 
-    it('passes value properly formatted when H24', () => {
+    it('passes value properly formatted', () => {
       const timePicker = new TimePicker({
         ...TimePicker.defaultProps,
         value: { hours: 15, minutes: 33 }
       });
       const { value } = timePicker.getLocals();
-      expect(value).toEqual('15:33');
-    });
-
-    it('passes value properly formatted when H12', () => {
-      const timePicker = new TimePicker({
-        ...TimePicker.defaultProps,
-        value: { hours: 15, minutes: 33 },
-        timeFormat: H12
-      });
-      const { value } = timePicker.getLocals();
-      expect(value).toEqual('15:33');
+      expect(value).toBe('15:33');
     });
 
     it('passes an undefined value when value prop is undefined', () => {

--- a/test/components/TimePicker.test.js
+++ b/test/components/TimePicker.test.js
@@ -49,7 +49,7 @@ describe('TimePicker', () => {
         value: { hours: 15, minutes: 33 }
       });
       const { value } = timePicker.getLocals();
-      expect(value).toEqual({ value: '15:33', label: '15:33' });
+      expect(value).toEqual('15:33');
     });
 
     it('passes value properly formatted when H12', () => {
@@ -59,7 +59,7 @@ describe('TimePicker', () => {
         timeFormat: H12
       });
       const { value } = timePicker.getLocals();
-      expect(value).toEqual({ value: '15:33', label: '03:33 pm' });
+      expect(value).toEqual('15:33');
     });
 
     it('passes an undefined value when value prop is undefined', () => {


### PR DESCRIPTION
Issue #663

## Test Plan

### tests performed
Start the react-component application
go to [http://localhost:8080/#/sections/components/component/time-picker](url)
select one of the options from the drop-down menu of the time-picker (either 12H or 24H format)
inspect the option of the selected time (to keep the menu opened while the devtool is opened click `cmd+F8+\`) 
The option should have the "is-selected" class

![image](https://cloud.githubusercontent.com/assets/22367312/20316808/cc9b74d6-ab63-11e6-853b-634512720bae.png)

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.}

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
