### PR TITLE
#667: [tablo perf] Create an isolated environment for testing (closes #667)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib
 generateChangelog.sh
 **/.tags
 **/.tags1
+showroom/components/IsolatedComponentView/Component*.js

--- a/npm-start.sh
+++ b/npm-start.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+set -e
+set -x
+
+TARGET="$1"
+
+case $TARGET in
+  "")
+    FILE_TARGET=""
+    ;;
+  "component")
+    FILE_TARGET="$TARGET."
+    ;;
+  *)
+    echo "Invalid target"
+    exit -1
+    ;;
+esac
+
+NODE_ENV=development webpack-dev-server \
+  --config showroom/webpack.${FILE_TARGET}config.babel.js \
+  --progress \
+  --hot \
+  --inline

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "preversion": "npm run lint && npm run lint-style && npm run test",
     "prepublish": "npm run build",
     "build-examples": "rm -rf examples/build && webpack --config examples/webpack.config.build.js --progress",
-    "start": "NODE_ENV=development webpack-dev-server --config showroom/webpack.config.babel.js --progress --hot --inline",
+    "start": "./npm-start.sh",
     "showroom": "NODE_ENV=test-showroom webpack-dev-server --config showroom/webpack.config.babel.js --progress --hot --inline",
     "build-showroom": "rm -rf ./showroom/build && webpack --config showroom/webpack.config.build.babel.js --progress && cp ./showroom/build/index.html ./index.html",
     "deploy-showroom": "./deployShowroom.sh",

--- a/showroom/app.component.js
+++ b/showroom/app.component.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Route, DefaultRoute, create } from 'react-router';
+import patchReactRouter from './patch-react-router';
+import App from './components/App';
+import IsolatedComponentView from './components/IsolatedComponentView';
+
+import 'buildo-normalize-css';
+import './styles.js';
+
+const routes = (
+  <Route name='main' path='/' handler={App}>
+    <DefaultRoute name='component' handler={IsolatedComponentView} />
+  </Route>
+);
+
+const router = patchReactRouter(create({ routes }));
+
+router.run((Handler, { params, query }) => {
+  // RENDERS
+  ReactDOM.render(<Handler {...{ router, params, query }} />, document.getElementById('app'));
+});

--- a/showroom/components/IsolatedComponentView/index.js
+++ b/showroom/components/IsolatedComponentView/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import Component from './Component';
+
+export default class IsolatedComponentView extends React.Component { // eslint-disable-line no-copy-paste-default-export/default
+  render() {
+    return <Component />;
+  }
+}

--- a/showroom/webpack.component.config.babel.js
+++ b/showroom/webpack.component.config.babel.js
@@ -1,0 +1,32 @@
+import path from 'path';
+import fs from 'fs';
+import webpackConfig from './webpack.config.babel';
+
+const paths = {
+  SHOWROOM: path.resolve(__dirname),
+  ISOLATE_COMPONENT: path.resolve(__dirname, 'components/IsolatedComponentView/Component.js')
+};
+
+const getComponentFileStat = (path) => {
+  try {
+    return fs.statSync(path);
+  }
+  catch (e) { console.log(e); }   // eslint-disable-line no-console
+};
+
+const stat = getComponentFileStat(paths.ISOLATE_COMPONENT);
+if (!stat || !stat.isFile()) {
+  const source = process.env.Component ||
+    'import React from \'react\';\n' +
+    `const component = () => <div>Hello, edit me in ${paths.ISOLATE_COMPONENT}</div>;\n` +
+    'export default component;';
+  fs.writeFileSync(paths.ISOLATE_COMPONENT, source);
+}
+
+export default {
+  ...webpackConfig,
+  entry: [
+    'webpack/hot/dev-server',
+    `${paths.SHOWROOM}/app.component.js`
+  ]
+};


### PR DESCRIPTION
Issue #667

## Test Plan

### tests performed
- `npm start component`
  - it creates the default `Component.js` file
  - pointing to `localhost:8080` => it renders a message that invites you to edit the `Component.js` file


- Edit `Component.js` and paste the content of [this](https://gist.github.com/veej/a4928a7e24e65e7e3e0e89ca293376d8) gist => isolated `Tablo` example!! YAY!!!!

- `npm start` still working as before