### PR TITLE
#680: Fix Tablo assert on children (closes #680)

### DIFF
--- a/src/tablo/Tablo.js
+++ b/src/tablo/Tablo.js
@@ -84,7 +84,7 @@ export default class Tablo extends React.Component {
     }).map((ch, key) => ch.type({ key, ...ch.props }));
 
     t.assert(
-      columnsOrGroups.length === ([].concat(children) || Object.keys).length,
+      columnsOrGroups.length === [].concat(children || Object.keys(data[0])).length,
       'There are extraneous children in the Grid. One should use only Column or ColumnGroup'
     );
 


### PR DESCRIPTION
Issue #680

## Test Plan
- export `Tablo` as is, without decorators (if you do, `sortable` will add `children` for you and the assert will pass anyway)
- use it without `children`
- you shouldn't get errors in the console