### PR TITLE
#682: SelectionType should be optional (closes #682)

### DIFF
--- a/src/tablo/plugins/selectable/selectableGrid.js
+++ b/src/tablo/plugins/selectable/selectableGrid.js
@@ -9,7 +9,7 @@ const propsTypes = {
   className: maybe(t.String),
   selectedRows: maybe(list(t.Integer)),
   onRowsSelect: maybe(t.Function),
-  selectionType: enums.of(['multi', 'single', 'none']),
+  selectionType: maybe(enums.of(['multi', 'single', 'none'])),
   hoveredRowIndex: maybe(t.Integer),
   onHoveredRowChange: maybe(t.Function)
 };


### PR DESCRIPTION
Issue #682

## Test Plan

### tests performed
- not passing `selectionType` to `Tablo` shouldn't raise warnings/errors in the console. The internal logic would set it to `none`