### PR TITLE
Revert "Update dependencies to enable Greenkeeper 🌴"

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-dnd": "^2.1.4",
     "react-dnd-html5-backend": "^2.1.2",
     "react-flexview": "1.0.1",
-    "react-input-children": "1.0.0",
+    "react-input-children": "1.0.1",
     "react-select": "1.0.0-rc.1",
     "revenge": "^0.4.2",
     "sass-flex-mixins": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "react-dnd": "^2.1.4",
     "react-dnd-html5-backend": "^2.1.2",
     "react-flexview": "1.0.1",
-    "react-input-children": "1.0.1",
-    "react-select": "1.0.0-rc.2",
+    "react-input-children": "1.0.0",
+    "react-select": "1.0.0-rc.1",
     "revenge": "^0.4.2",
     "sass-flex-mixins": "^0.1.0",
     "tcomb-react": "^0.9.0"


### PR DESCRIPTION
Reverts buildo/react-components#677

Sorry @greenkeeperio-bot but I don't trust `react-select@1.0.0-rc2` as:
- it's not officially published
- there's not release on its repo
- there's not changelog but it has [106 freaking new commits](https://github.com/JedWatson/react-select/compare/v1.0.0-rc.1...master) compared to `react-select@1.0.0-rc1`