### PR TITLE
#701: Popover: delay prop validation always fails if you pass an object (closes #701)

### DIFF
--- a/src/popover/Popover.js
+++ b/src/popover/Popover.js
@@ -29,7 +29,7 @@ export const Props = {
     isOpen: t.maybe(t.Boolean),
     delay: t.maybe(t.union([
       t.Integer,
-      t.struct({ whenClosed: t.maybe(t.Integer), whenOpen: t.maybe(t.Integer) })
+      t.interface({ whenClosed: t.maybe(t.Integer), whenOpen: t.maybe(t.Integer) })
     ]))
   }),
   id: t.maybe(t.String),


### PR DESCRIPTION
Issue #701

## Test Plan

### tests performed
- warning is no longer there :)
- pass `delay={{ whenOpen: 100, ciao: true }}`
  ~~- tcomb complains (`interface` is indeed `strict`)~~

~~PS: We were using `t.interface` only in `Modal`:~~
![image](https://cloud.githubusercontent.com/assets/4029499/21266550/00014a52-c3a7-11e6-82f7-af6d6daac2ce.png)

~~Also in this case it's correct to make it `strict`~~


### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
