### PR TITLE
#713: [Tablo Perf] horizontal virtualization should be settable and on by default (closes #713)

### DIFF
--- a/src/tablo/API.md
+++ b/src/tablo/API.md
@@ -40,3 +40,4 @@ A table component based on fixed-data-table-2
 | **fixed** | <code>Boolean</code> | <code>true</code>| *optional*. Used to set the column to fixed, it will be pulled to the left and it will not scroll with the rest of the columns
 | **sortable** | <code>Boolean</code> | <code>true</code>| *optional*. Used to exclude the columns from the sortable fields. It is default <code>true</code> if the `onSortChange` callback is provided to the Tablo component
 | **isResizable** | <code>Boolean</code> | <code>true</code>| *optional*. Used to make the column's width not modifiable. It is default <code>true</code> if the `onColumnResize` callback is provided to the Tablo component
+| **allowCellsRecycling** | <code>Boolean</code> | <code>true</code>| *optional*. Used to enable horizontal virtualization for the cells of this column

--- a/src/tablo/Column/Column.js
+++ b/src/tablo/Column/Column.js
@@ -20,6 +20,7 @@ const argsTypes = struct({
   fixed: maybe(t.Boolean),
   flexGrow: maybe(t.Number),
   children: t.ReactChildren,
+  allowCellsRecycling: maybe(t.Boolean),
 
   isResizable: maybe(t.Boolean)
 }, { strict: true });
@@ -34,7 +35,8 @@ const Column = (args) => {
     name,
     fixed,
     isResizable,
-    children = []
+    children = [],
+    allowCellsRecycling = true
   } = argsTypes(args);
 
   const cell = ({ rowIndex, columnKey }) => {
@@ -57,6 +59,7 @@ const Column = (args) => {
       flexGrow={flexGrow}
       fixed={fixed}
       isResizable={isResizable}
+      allowCellsRecycling={allowCellsRecycling}
     />
   );
 };


### PR DESCRIPTION
Issue #713

## Test Plan

### tests performed
- log `allowCellsRecycling` prop
  - `allowCellsRecycling` is `true` by default
- explicitly pass `allowCellsRecycling={false}`
  - `allowCellsRecycling` is `false`

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
