### PR TITLE
#714: [Tablo Perf] handle hover style for rows in CSS (closes #714)

### DIFF
--- a/src/tablo/API.md
+++ b/src/tablo/API.md
@@ -13,8 +13,6 @@ A table component based on fixed-data-table-2
 | **selectionType** | <code>multi &#124; single &#124; none</code> |  <code>none</code> | *optional*.
 | **selectedRows** | <code>Array(Integer)</code> | | *optional*. List of selected rows' indexes
 | **onRowsSelect** | <code>Function</code> | | *optional*. Callback to handle <code>selectedRows</code> prop. An array with the indexes of selected rows is passed as parameter
-| **hoveredRowIndex** | <code>Integer</code> | | *optional*.
-| **onHoveredRowChange** | <code>Function</code> | | *optional*. Callback to handle <code>hoveredRowIndex</code> prop. The <code>rowNumber</code> being hovered is passed as parameter (rowNumber will be set to <code>null</code> if no rows are hovered)
 | **onSortChange** | <code>Function</code> | | *optional*. Callback to handle <code>sortBy</code> and <code>sortDir</code>props. Called when a header of a sortable column is clicked. An object containing the <code>sortBy</code> and <code>sortDir</code> strings is passed as parameter.
 | **sortBy** | <code>String</code> |  | *optional*. key (name) of the field for which the table is sorted
 | **sortDir** | <code>asc &#124; desc</code> |  | *optional*. Whether to show an ascending or descending icon. Required if <code>sortBy</code> is provided

--- a/src/tablo/examples/default.js
+++ b/src/tablo/examples/default.js
@@ -22,10 +22,6 @@ class Example extends React.Component {
     });
   };
 
-  onHoveredRowChange = (rowIndex) => {
-    this.setState({ hoveredRowIndex: rowIndex });
-  }
-
   onRowsSelect = (selectedRows) => {
     this.setState({ selectedRows });
   }
@@ -37,8 +33,8 @@ class Example extends React.Component {
   render() {
 
     const {
-      rowHeight, onSortChange, onColumnResize, onHoveredRowChange, onRowsSelect, onColumnsReorder,
-      state: { sortBy: sortByField, sortDir, columnWidths, hoveredRowIndex, selectedRows, columnsOrder }
+      rowHeight, onSortChange, onColumnResize, onRowsSelect, onColumnsReorder,
+      state: { sortBy: sortByField, sortDir, columnWidths, selectedRows, columnsOrder }
     } = this;
 
     const sortedData = sortBy(data, sortByField);
@@ -53,8 +49,6 @@ class Example extends React.Component {
           sortDir={sortDir}
           onColumnResize={onColumnResize}
           selectionType='single'
-          hoveredRowIndex={hoveredRowIndex}
-          onHoveredRowChange={onHoveredRowChange}
           selectedRows={selectedRows}
           onRowsSelect={onRowsSelect}
           columnsOrder={columnsOrder}

--- a/src/tablo/plugins/selectable/selectableGrid.js
+++ b/src/tablo/plugins/selectable/selectableGrid.js
@@ -9,9 +9,7 @@ const propsTypes = {
   className: maybe(t.String),
   selectedRows: maybe(list(t.Integer)),
   onRowsSelect: maybe(t.Function),
-  selectionType: maybe(enums.of(['multi', 'single', 'none'])),
-  hoveredRowIndex: maybe(t.Integer),
-  onHoveredRowChange: maybe(t.Function)
+  selectionType: maybe(enums.of(['multi', 'single', 'none']))
 };
 
 const getLocals = ({
@@ -19,8 +17,6 @@ const getLocals = ({
   onRowsSelect,
   selectionType = 'none',
   className,
-  onHoveredRowChange,
-  hoveredRowIndex,
   ...gridProps }) => {
 
   const onRowClick = ({ ctrlKey, metaKey }, index) => {
@@ -38,20 +34,9 @@ const getLocals = ({
     }
   };
 
-  const onRowMouseEnter = (_, index) => {
-    onHoveredRowChange && onHoveredRowChange(index);
-  };
-
-  const onRowMouseLeave = () => {
-    onHoveredRowChange && onHoveredRowChange(null);
-  };
-
-  const rowClassNameGetter = (index) => cx(
-    'tablo-row', {
-      selected: includes(selectedRows, index),
-      hover: index === hoveredRowIndex
-    }
-  );
+  const rowClassNameGetter = (index) => cx('tablo-row', {
+    selected: includes(selectedRows, index)
+  });
 
   const scrollToRow = !gridProps.scrollTop ? selectedRows[0] : undefined;
 
@@ -60,8 +45,6 @@ const getLocals = ({
     scrollToRow,
     onRowClick,
     rowClassNameGetter,
-    onRowMouseEnter,
-    onRowMouseLeave,
     ...gridProps
   };
 };

--- a/src/tablo/plugins/selectable/selectableGrid.scss
+++ b/src/tablo/plugins/selectable/selectableGrid.scss
@@ -6,11 +6,7 @@
     .tablo-row {
       cursor: pointer;
 
-      &.hover .public_fixedDataTableCell_main {
-        background: $hover-cell-background;
-      }
-
-      &.selected .public_fixedDataTableCell_main {
+      &.selected:not(:hover) .public_fixedDataTableCell_main {
         background: $selected-cell-background;
       }
     }

--- a/src/tablo/plugins/selectable/selectableGrid.scss
+++ b/src/tablo/plugins/selectable/selectableGrid.scss
@@ -9,6 +9,10 @@
       &.selected:not(:hover) .public_fixedDataTableCell_main {
         background: $selected-cell-background;
       }
+
+      &.selected:hover .public_fixedDataTableCell_main {
+        background: $hover-selected-cell-background;
+      }
     }
   }
 }

--- a/src/tablo/tablo.scss
+++ b/src/tablo/tablo.scss
@@ -80,6 +80,10 @@
       }
     }
   }
+
+  .tablo-row:hover .public_fixedDataTableCell_main {
+    background: $hover-cell-background;
+  }
 }
 
 .tablo {

--- a/src/tablo/tabloVariables.scss
+++ b/src/tablo/tabloVariables.scss
@@ -15,3 +15,4 @@ $hover-scrollbar-color: $brc-coolGrey !default;
 $scrollbar-size: 6px !default;
 $selected-cell-background: #eaf4fd !default;
 $hover-cell-background: #f5fafe !default;
+$hover-selected-cell-background: $hover-cell-background !default;


### PR DESCRIPTION
Issue #714

## Test Plan

### tests performed
- hover a row in `default` example
  - row background is colored correctly
- select a row and hover it
  - row background is set to the hover one (hover beats select)
- pass `onRowMouseEnter` and `onRowMouseLeave` to `Tablo`
  - correctly called when entering/leaving a row

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
