### PR TITLE
#721: Panel: header height should be configurable (closes #721)

### DIFF
--- a/src/Panel/Panel.js
+++ b/src/Panel/Panel.js
@@ -149,7 +149,7 @@ export default class Panel extends React.Component {
       header ?
         <PanelHeader
           title={header.hideTitleWhenExpanded && isExpanded ? undefined : header.title}
-          size={header.size || HeaderSize('small')}
+          size={header.size}
           content={header.content}
           menu={header.menu}
           collapse={header.collapse ? {

--- a/src/Panel/Panel.js
+++ b/src/Panel/Panel.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 import { props, t, skinnable, pure } from '../utils';
-import PanelHeader from './PanelHeader';
+import PanelHeader, { HeaderSize } from './PanelHeader';
 import capitalize from 'lodash/capitalize';
 import LoadingSpinner from '../loading-spinner/LoadingSpinner';
 import FlexView from 'react-flexview';
@@ -15,7 +15,7 @@ export const Props = {
       onCollapse: t.Func,
       isCollapsed: t.maybe(t.Bool)
     })),
-    height: t.maybe(t.Integer),
+    size: t.maybe(HeaderSize),
     content: t.maybe(t.ReactChildren),
     title: t.maybe(t.ReactChildren),
     hideTitleWhenExpanded: t.maybe(t.Bool),
@@ -149,7 +149,7 @@ export default class Panel extends React.Component {
       header ?
         <PanelHeader
           title={header.hideTitleWhenExpanded && isExpanded ? undefined : header.title}
-          height={header.height || 40}
+          size={header.size || HeaderSize('small')}
           content={header.content}
           menu={header.menu}
           collapse={header.collapse ? {

--- a/src/Panel/Panel.js
+++ b/src/Panel/Panel.js
@@ -15,6 +15,7 @@ export const Props = {
       onCollapse: t.Func,
       isCollapsed: t.maybe(t.Bool)
     })),
+    height: t.maybe(t.Integer),
     content: t.maybe(t.ReactChildren),
     title: t.maybe(t.ReactChildren),
     hideTitleWhenExpanded: t.maybe(t.Bool),
@@ -148,6 +149,7 @@ export default class Panel extends React.Component {
       header ?
         <PanelHeader
           title={header.hideTitleWhenExpanded && isExpanded ? undefined : header.title}
+          height={header.height || 40}
           content={header.content}
           menu={header.menu}
           collapse={header.collapse ? {

--- a/src/Panel/PanelHeader.js
+++ b/src/Panel/PanelHeader.js
@@ -29,6 +29,10 @@ export const HeaderSize = t.enums.of(headerSizes, 'HeaderSize');
 })
 export default class PanelHeader extends React.Component {
 
+  static defaultProps={
+    size: HeaderSize('small')
+  };
+
   getIcon = (collapse) => {
     const { direction, isExpanded } = collapse;
     return isExpanded ? icons[direction][0] : icons[direction][1];

--- a/src/Panel/PanelHeader.js
+++ b/src/Panel/PanelHeader.js
@@ -18,6 +18,7 @@ const icons = {
     direction: t.enums.of(Object.keys(icons)),
     onToggleExpanded: t.Func
   })),
+  height: t.Integer,
   title: t.maybe(t.ReactChildren),
   content: t.maybe(t.ReactChildren),
   menu: t.maybe(t.ReactChildren)
@@ -30,7 +31,7 @@ export default class PanelHeader extends React.Component {
   };
 
   getLocals() {
-    const { collapse, content, title, menu } = this.props;
+    const { collapse, height, content, title, menu } = this.props;
     const verticalDirection = collapse && (collapse.direction === 'up' || collapse.direction === 'down');
     const renderExpandIcon = !!collapse;
     const renderInnerHeader = !collapse || collapse && (collapse.isExpanded || verticalDirection);
@@ -39,6 +40,7 @@ export default class PanelHeader extends React.Component {
     const renderMenu = menu && renderInnerHeader;
     return {
       collapse,
+      height,
       content,
       title,
       menu,
@@ -84,9 +86,9 @@ export default class PanelHeader extends React.Component {
     );
   };
 
-  template({ collapse, content, title, menu, renderExpandIcon, renderTitle, renderContent, renderMenu }) {
+  template({ collapse, height, content, title, menu, renderExpandIcon, renderTitle, renderContent, renderMenu }) {
     return (
-      <FlexView className='panel-header' basis={40}>
+      <FlexView className='panel-header' basis={height}>
         {this.templateTitle({ renderTitle, title, renderExpandIcon, collapse })}
         {this.templateContent({ renderContent, content })}
         {renderMenu && menu}

--- a/src/Panel/PanelHeader.js
+++ b/src/Panel/PanelHeader.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { props, t, pure, skinnable } from '../utils';
+import { props, t, pure, skinnable, stateClassUtil } from '../utils';
 import FlexView from 'react-flexview';
 import Icon from '../Icon/Icon';
+import cx from 'classnames';
 
 const icons = {
   up: ['angle-up', 'angle-down'],
@@ -9,6 +10,9 @@ const icons = {
   down: ['angle-down', 'angle-up'],
   right: ['angle-right', 'angle-left']
 };
+
+const headerSizes = ['tiny', 'small', 'medium'];
+export const HeaderSize = t.enums.of(headerSizes, 'HeaderSize');
 
 @pure
 @skinnable()
@@ -18,7 +22,7 @@ const icons = {
     direction: t.enums.of(Object.keys(icons)),
     onToggleExpanded: t.Func
   })),
-  height: t.Integer,
+  size: HeaderSize,
   title: t.maybe(t.ReactChildren),
   content: t.maybe(t.ReactChildren),
   menu: t.maybe(t.ReactChildren)
@@ -31,15 +35,18 @@ export default class PanelHeader extends React.Component {
   };
 
   getLocals() {
-    const { collapse, height, content, title, menu } = this.props;
+    const { collapse, size, content, title, menu } = this.props;
     const verticalDirection = collapse && (collapse.direction === 'up' || collapse.direction === 'down');
     const renderExpandIcon = !!collapse;
     const renderInnerHeader = !collapse || collapse && (collapse.isExpanded || verticalDirection);
     const renderTitle = title && renderInnerHeader;
     const renderContent = content && renderInnerHeader;
     const renderMenu = menu && renderInnerHeader;
+    const height = size === HeaderSize('tiny') ? 40 : size === HeaderSize('medium') ? 56 : 48;
+    const className = cx('panel-header', stateClassUtil(size));
     return {
       collapse,
+      className,
       height,
       content,
       title,
@@ -86,9 +93,9 @@ export default class PanelHeader extends React.Component {
     );
   };
 
-  template({ collapse, height, content, title, menu, renderExpandIcon, renderTitle, renderContent, renderMenu }) {
+  template({ collapse, className, height, content, title, menu, renderExpandIcon, renderTitle, renderContent, renderMenu }) {
     return (
-      <FlexView className='panel-header' basis={height}>
+      <FlexView className={className} basis={height}>
         {this.templateTitle({ renderTitle, title, renderExpandIcon, collapse })}
         {this.templateContent({ renderContent, content })}
         {renderMenu && menu}


### PR DESCRIPTION
Issue #721

## Test Plan

### tests performed
- if size is not specified, or `size='small'`, header height is 48px
![image](https://cloud.githubusercontent.com/assets/925635/21566316/3fb2e70e-cea2-11e6-812a-50a735447be3.png)

- adding size = `medium`, header height is 56px
![image](https://cloud.githubusercontent.com/assets/925635/21566293/0e8cc3e8-cea2-11e6-8774-de7885e8c57a.png)

- adding `size='small'`, header height is 40px
![image](https://cloud.githubusercontent.com/assets/925635/21566306/2b7ee1d4-cea2-11e6-8851-404c6aa4d572.png)
