### PR TITLE
#671: Modal renders header/footer even when not necessary (closes #671)

### DIFF
--- a/showroom/components.json
+++ b/showroom/components.json
@@ -205,6 +205,14 @@
         "examples": [
           {
             "url": "modal/examples/default.js"
+          },
+          {
+            "title": "Modal without header",
+            "url": "modal/examples/noHeader.js"
+          },
+          {
+            "title": "Modal without footer",
+            "url": "modal/examples/noFooter.js"
           }
         ]
       },

--- a/src/modal/Modal.js
+++ b/src/modal/Modal.js
@@ -52,9 +52,13 @@ export default class Modal extends React.Component {
   };
 
   getLocals() {
-    const { className, ...props } = this.props;
+    const { className, title, iconClose, footer, ...props } = this.props;
     return {
       ...props,
+      shouldRenderHeader: !!title || !!iconClose,
+      title, iconClose,
+      shouldRenderFooter: !!footer,
+      footer,
       modalPortalProps: {
         ...omit(props, Object.keys(ModalProps)),
         className: cx('modal', className)
@@ -63,7 +67,9 @@ export default class Modal extends React.Component {
   }
 
   template({
-    children, title, iconClose, footer,
+    shouldRenderHeader, title, iconClose,
+    children,
+    shouldRenderFooter, footer,
     dismissOnClickOutside, onDismiss, overlay,
     style, id, modalPortalProps
   }) {
@@ -75,27 +81,31 @@ export default class Modal extends React.Component {
           maxWidth={950}
         >
           <FlexView className='modal-content' column grow >
-            <FlexView className='modal-header' shrink={false} vAlignContent='center'>
-              <FlexView className={cx('modal-title')} grow>
-                {title}
-              </FlexView>
-              {iconClose && (
-                <FlexView
-                  className='modal-icon-close'
-                  shrink={false}
-                  marginLeft='auto'
-                  onClick={onDismiss}
-                >
-                  {iconClose}
+            {shouldRenderHeader && (
+              <FlexView className='modal-header' shrink={false} vAlignContent='center'>
+                <FlexView className={cx('modal-title')} grow>
+                  {title}
                 </FlexView>
-              )}
-            </FlexView>
+                {iconClose && (
+                  <FlexView
+                    className='modal-icon-close'
+                    shrink={false}
+                    marginLeft='auto'
+                    onClick={onDismiss}
+                  >
+                    {iconClose}
+                  </FlexView>
+                )}
+              </FlexView>
+            )}
             <FlexView className='modal-body' column grow>
               {children}
             </FlexView>
-            <FlexView className='modal-footer' column shrink={false}>
-              {footer}
-            </FlexView>
+            {shouldRenderFooter && (
+              <FlexView className='modal-footer' column shrink={false}>
+                {footer}
+              </FlexView>
+            )}
           </FlexView>
         </BackgroundDimmer>
       </ModalPortal>

--- a/src/modal/examples/noFooter.js
+++ b/src/modal/examples/noFooter.js
@@ -1,8 +1,6 @@
 class Example extends React.Component {
-  constructor() {
-    super();
-    this.state = { isOpen: false };
-  }
+
+  state = { isOpen: false }
 
   open = () => this.setState({ isOpen: true })
 
@@ -14,15 +12,9 @@ class Example extends React.Component {
       transitionLeaveTimeout={500}
       onDismiss={this.close}
       iconClose={<Icon icon='close' />}
-      title='Send Message'
-      footer={
-        <FlexView hAlignContent='right'>
-          <Button default size='small' style={{ marginRight: 10 }} onClick={this.close}>Cancel</Button>
-          <Button primary size='small' onClick={this.close}>Confirm</Button>
-        </FlexView>
-      }
+      title='Informative Modal'
     >
-      Are you sure you want to send this message?
+      This modal contains just info. So it is not possible to perform an action.
     </Modal>
   )
 

--- a/src/modal/examples/noHeader.js
+++ b/src/modal/examples/noHeader.js
@@ -1,8 +1,6 @@
 class Example extends React.Component {
-  constructor() {
-    super();
-    this.state = { isOpen: false };
-  }
+
+  state = { isOpen: false }
 
   open = () => this.setState({ isOpen: true })
 
@@ -13,8 +11,6 @@ class Example extends React.Component {
       transitionEnterTimeout={500}
       transitionLeaveTimeout={500}
       onDismiss={this.close}
-      iconClose={<Icon icon='close' />}
-      title='Send Message'
       footer={
         <FlexView hAlignContent='right'>
           <Button default size='small' style={{ marginRight: 10 }} onClick={this.close}>Cancel</Button>


### PR DESCRIPTION
Issue #671

## Test Plan

### tests performed
Added 2 examples for test purpose:
 - modal with no header
 - modal with no footer

Shouldn't this be breaking?

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
