### PR TITLE
#731: Dropdown: expose focus function (closes #731)

### DIFF
--- a/src/dropdown/Dropdown.js
+++ b/src/dropdown/Dropdown.js
@@ -110,6 +110,8 @@ export default class Dropdown extends React.Component {
     }
   }
 
+  focus = () => { this.select.focus(); }
+
   getLocals() {
     const {
       _onChange,
@@ -132,6 +134,6 @@ export default class Dropdown extends React.Component {
   }
 
   template(locals) {
-    return <Select {...locals} />;
+    return <Select {...locals} ref={select => { this.select = select; }} />;
   }
 }


### PR DESCRIPTION
Issue #731

## Test Plan

### tests performed
Tested passing a `onValueClick` function that focus the input after erasing the selected value:

![](https://i.gyazo.com/9d988a80be0e0906b68f78a017a72891.gif)