### PR TITLE
#741: Tablo: expose `rowClassNameGetter` (closes #741)

### DIFF
--- a/src/tablo/API.md
+++ b/src/tablo/API.md
@@ -28,6 +28,7 @@ A table component based on fixed-data-table-2
 | **onScrollStart** | <code>Function</code> |  | *optional*. Callback to be called when scrolling starts |
 | **onScrollEnd** | <code>Function</code> |  | *optional*. Callback to be called when scrolling ends |
 | **children** | <code>ReactChildren</code> |  | *optional*. Table children (Column or ColumnGroup). If left undefined, columns will be populated automatically with data|
+| **rowClassNameGetter** | <code>Function</code> |  | *optional*. Function: <code>(index) => className</code> of row of index <code>index</code>|
 
 ## Column Props
 |Name|Type|Default|Description|

--- a/src/tablo/Tablo.js
+++ b/src/tablo/Tablo.js
@@ -4,6 +4,7 @@ import { pure, skinnable, props, t } from '../utils';
 import { Table } from 'fixed-data-table-2';
 import Column, { defaultColumns, updateColumns } from './Column';
 import FlexView from 'react-flexview';
+import constant from 'lodash/constant';
 
 import './patch-fixed-data-table-2';
 
@@ -36,10 +37,11 @@ const { maybe } = t;
  * @param sortBy - id of the column according which the data should be ordered
  * @param sortDir - sorting direction
  * @param onSortChange - callback to be called when sorting change
+ * @param rowClassNameGetter - a function index -> className
+
  *
  * @param scrollToRow - Private
  * @param onRowClick - Private
- * @param rowClassNameGetter - Private
  * @param onColumnResizeEndCallback - Private
  * @param isColumnResizing - Private
  */
@@ -62,24 +64,25 @@ const { maybe } = t;
   onScrollStart: maybe(t.Function),
   onScrollEnd: maybe(t.Function),
   children: t.ReactChildren,
+  rowClassNameGetter: maybe(t.Function),
 
   // private
   scrollToRow: maybe(t.Integer),
   onRowClick: maybe(t.Function),
-  rowClassNameGetter: maybe(t.Function),
   onColumnResizeEndCallback: maybe(t.Function),
   isColumnResizing: maybe(t.Boolean)
 })
 export default class Tablo extends React.Component {
 
   static defaultProps = {
+    rowClassNameGetter: constant(''),
     rowHeight: 30,
     headerHeight: 40,
     groupHeaderHeight: 50,
     footerHeight: 0
   }
 
-  getLocals({ data, children, ...tableProps }) {
+  getLocals({ data, children, rowClassNameGetter: rcnGetter, ...tableProps }) {
 
     const columnsOrGroups = updateColumns(children || defaultColumns(data), ({ col }) => {
       return <Column {...{ key: col.props.name, ...col.props, data }} />;
@@ -90,11 +93,16 @@ export default class Tablo extends React.Component {
       'There are extraneous children in the Grid. One should use only Column or ColumnGroup'
     );
 
+    const rowClassNameGetter = (index) => {
+      return cx('tablo-row', rcnGetter(index));
+    };
+
     const rowsCount = data.length;
 
     return {
       columnsOrGroups,
       rowsCount,
+      rowClassNameGetter,
       ...tableProps
     };
   }

--- a/src/tablo/Tablo.js
+++ b/src/tablo/Tablo.js
@@ -4,7 +4,6 @@ import { pure, skinnable, props, t } from '../utils';
 import { Table } from 'fixed-data-table-2';
 import Column, { defaultColumns, updateColumns } from './Column';
 import FlexView from 'react-flexview';
-import constant from 'lodash/constant';
 
 import './patch-fixed-data-table-2';
 
@@ -75,7 +74,7 @@ const { maybe } = t;
 export default class Tablo extends React.Component {
 
   static defaultProps = {
-    rowClassNameGetter: constant(''),
+    rowClassNameGetter: () => '',
     rowHeight: 30,
     headerHeight: 40,
     groupHeaderHeight: 50,

--- a/src/tablo/examples/default.js
+++ b/src/tablo/examples/default.js
@@ -42,6 +42,7 @@ class Example extends React.Component {
     return (
       <FlexView style={{ height: 300, width: '100%' }}>
         <Tablo
+          rowClassNameGetter={index => `row-${index}`}
           data={sortDir === 'desc' ? sortedData.reverse() : sortedData}
           rowHeight={rowHeight}
           onSortChange={onSortChange}
@@ -103,4 +104,3 @@ const getRandomRow = () => {
 };
 
 const data = Array.apply(null, Array(30)).reduce(acc => [...acc, getRandomRow()], []);
-

--- a/src/tablo/plugins/selectable/selectableGrid.js
+++ b/src/tablo/plugins/selectable/selectableGrid.js
@@ -2,7 +2,6 @@ import React from 'react';
 import cx from 'classnames';
 import { pure, skinnable, props, t, contains } from '../../../utils';
 import includes from 'lodash/includes';
-import constant from 'lodash/constant';
 
 const { list, maybe, enums } = t;
 
@@ -18,7 +17,7 @@ const getLocals = ({
   onRowsSelect,
   selectionType = 'none',
   className,
-  rowClassNameGetter: rcnGetter = constant(''),
+  rowClassNameGetter: rcnGetter = () => '',
   ...gridProps }) => {
 
   const onRowClick = ({ ctrlKey, metaKey }, index) => {

--- a/src/tablo/plugins/selectable/selectableGrid.js
+++ b/src/tablo/plugins/selectable/selectableGrid.js
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import { pure, skinnable, props, t, contains } from '../../../utils';
 import includes from 'lodash/includes';
+import constant from 'lodash/constant';
 
 const { list, maybe, enums } = t;
 
@@ -17,6 +18,7 @@ const getLocals = ({
   onRowsSelect,
   selectionType = 'none',
   className,
+  rowClassNameGetter: rcnGetter = constant(''),
   ...gridProps }) => {
 
   const onRowClick = ({ ctrlKey, metaKey }, index) => {
@@ -34,7 +36,7 @@ const getLocals = ({
     }
   };
 
-  const rowClassNameGetter = (index) => cx('tablo-row', {
+  const rowClassNameGetter = (index) => cx(rcnGetter(index), {
     selected: includes(selectedRows, index)
   });
 


### PR DESCRIPTION
Issue #741

## Test Plan

### tests performed
tested in the examples
- especially the screenshot shows that the both the `selected` class is added and both the one returned by `rowClassNameGetter(index)`

![image](https://cloud.githubusercontent.com/assets/3280300/22518117/c59c015c-e8ab-11e6-88ae-6795bcab2576.png)

![image](https://cloud.githubusercontent.com/assets/3280300/22518130/d1f3fb76-e8ab-11e6-96d0-4ccb3b732aad.png)

