### PR TITLE
#750: Tablo: in IE11 sort icons are misaligned (closes #750)

### DIFF
--- a/src/tablo/plugins/sortable/Arrow.js
+++ b/src/tablo/plugins/sortable/Arrow.js
@@ -11,7 +11,7 @@ const propsTypes = {
 
 const template = ({ arrowDir, className }) => {
   return (
-    <FlexView column vAlignContent='center' className={cx('arrow', className )}>
+    <FlexView column vAlignContent='center' height='100%' className={cx('arrow', className )}>
       {arrowDir !== 'down' && <FlexView className='up' marginBottom={arrowDir !== 'up' ? 2 : 0} />}
       {arrowDir !== 'up' && <FlexView className='down' marginTop={arrowDir !== 'down' ? 2 : 0}  />}
     </FlexView>


### PR DESCRIPTION
Issue #750

## Test Plan

### tests performed
![image](https://cloud.githubusercontent.com/assets/3280300/22704945/dba8be00-ed69-11e6-94d2-6335ce9dddbc.png)
