### PR TITLE
#755: Tablo: ui changes (closes #755)

### DIFF
--- a/src/tablo/plugins/columnsReorder/DNDHeader.js
+++ b/src/tablo/plugins/columnsReorder/DNDHeader.js
@@ -4,6 +4,8 @@ import { findDOMNode } from 'react-dom';
 import { DropTarget, DragSource } from 'react-dnd';
 import { pure, skinnable, props, t } from '../../../utils';
 import FlexView from 'react-flexview';
+import flowRight from 'lodash/flowRight';
+import identity from 'lodash/identity';
 
 const columnTarget = {
   canDrop({ isDropAllowed, name: target }, monitor) {
@@ -90,18 +92,23 @@ const columnType = ({ tabloUniqueId }) => `${tabloUniqueId}_column`;
 })
 export default class DNDHeader extends React.Component {
 
-  template({ connectDragSource, connectDragPreview, connectDropTarget, isDragAllowed, isDragging, canDrop, isOver, children }) {
-    return connectDropTarget(connectDragPreview(
+  getLocals({ connectDragSource, connectDragPreview, connectDropTarget, isDragAllowed, ...props }) {
+    const dndWrapper = isDragAllowed ? flowRight(connectDropTarget, connectDragPreview, connectDragSource) : identity;
+    return {
+      dndWrapper,
+      ...props
+    };
+  }
+
+  template({ dndWrapper, isDragging, canDrop, isOver, children }) {
+    return dndWrapper(
       <div className={cx('dndHeader', { isDragging, canDrop, isOver })}>
         <FlexView vAlignContent='center' width='100%' height='100%'>
-          {isDragAllowed && connectDragSource(
-            <span className='grip' />
-          )}
           <FlexView grow height='100%' vAlignContent='center'>
             {children}
           </FlexView>
         </FlexView>
       </div>
-    ));
+    );
   }
 }

--- a/src/tablo/plugins/columnsReorder/DNDHeader.js
+++ b/src/tablo/plugins/columnsReorder/DNDHeader.js
@@ -92,8 +92,8 @@ const columnType = ({ tabloUniqueId }) => `${tabloUniqueId}_column`;
 })
 export default class DNDHeader extends React.Component {
 
-  getLocals({ connectDragSource, connectDragPreview, connectDropTarget, isDragAllowed, ...props }) {
-    const dndWrapper = isDragAllowed ? flowRight(connectDropTarget, connectDragPreview, connectDragSource) : identity;
+  getLocals({ connectDragSource, connectDropTarget, isDragAllowed, ...props }) {
+    const dndWrapper = isDragAllowed ? flowRight(connectDropTarget, connectDragSource) : identity;
     return {
       dndWrapper,
       ...props

--- a/src/tablo/plugins/columnsReorder/columnsReorderGrid.scss
+++ b/src/tablo/plugins/columnsReorder/columnsReorderGrid.scss
@@ -11,24 +11,7 @@
     @include flex_align-items('center');
 
     &.isDragging {
-      opacity: .6;
-    }
-
-    span.grip {
-      width: 20px;
-      height: 27px;
-      display: inline-block;
-      overflow: hidden;
-      line-height: 5px;
-      padding: 0 4px;
-      cursor: move;
-      font-size: 18px;
-      letter-spacing: 2px;
-      color: 1px 0 1px $header-color;
-    }
-
-    span.grip::after {
-      content: '.. .. ..';
+      opacity: $columns-reorder-header-opacity-is-dragging;
     }
   }
 }

--- a/src/tablo/plugins/sortable/sortableGrid.scss
+++ b/src/tablo/plugins/sortable/sortableGrid.scss
@@ -7,20 +7,20 @@
 
     .sort-icon {
       color: $header-color;
-      opacity: .4;
+      opacity: $sortable-grid-arrows-opacity;
     }
 
     &.sorted .sort-icon {
-      opacity: 1;
+      opacity: $sortable-grid-sorted-arrows-opacity;
     }
 
     &:hover {
       .sort-icon {
-        opacity: 1;
+        opacity: $sortable-grid-arrows-opacity-hover;
       }
 
       &.sorted .sort-icon {
-        opacity: .4;
+        opacity: $sortable-grid-sorted-arrows-opacity-hover;
       }
     }
   }

--- a/src/tablo/tabloVariables.scss
+++ b/src/tablo/tabloVariables.scss
@@ -27,3 +27,5 @@ $sortable-grid-arrows-opacity: .4 !default;
 $sortable-grid-arrows-opacity-hover: 1 !default;
 $sortable-grid-sorted-arrows-opacity: 1 !default;
 $sortable-grid-sorted-arrows-opacity-hover: .4 !default;
+
+$columns-reorder-header-opacity-is-dragging: .6 !default;

--- a/src/tablo/tabloVariables.scss
+++ b/src/tablo/tabloVariables.scss
@@ -22,3 +22,8 @@ $cell-border-color: $brc-silver !default;
 $cell-background-selected: #eaf4fd !default;
 $cell-background-hover: #f5fafe !default;
 $cell-background-hover-selected: $cell-background-hover !default;
+
+$sortable-grid-arrows-opacity: .4 !default;
+$sortable-grid-arrows-opacity-hover: 1 !default;
+$sortable-grid-sorted-arrows-opacity: 1 !default;
+$sortable-grid-sorted-arrows-opacity-hover: .4 !default;


### PR DESCRIPTION
Issue #755

## Test Plan

![image](https://cloud.githubusercontent.com/assets/3280300/22856218/5f1320dc-f085-11e6-95d8-63b7dea9e9ab.png)


### tests performed
- `sortableGrid`: nothing should be changed, as the default values of the sass variables are the same used before in the source code
-  `columnsReorder`: there's no more a drag icon, the header is entirely draggable