### PR TITLE
#760: Tablo: background on hover should have different variables for even and odd rows (closes #760)

### DIFF
--- a/src/tablo/tablo.scss
+++ b/src/tablo/tablo.scss
@@ -26,12 +26,28 @@
   }
 
   // bg color for odd/even rows (applied to cells for reliability)
-  .public_fixedDataTableRow_odd .public_fixedDataTableCell_main {
-    background: $odd-row-background;
+  .public_fixedDataTableRow_odd {
+    .public_fixedDataTableCell_main {
+      background: $odd-row-background;
+    }
+
+    &:hover {
+      .public_fixedDataTableCell_main {
+        background: $cell-odd-row-background-hover;
+      }
+    }
   }
 
-  .public_fixedDataTableRow_even .public_fixedDataTableCell_main {
-    background: $even-row-background;
+  .public_fixedDataTableRow_even {
+    .public_fixedDataTableCell_main {
+      background: $even-row-background;
+    }
+
+    &:hover {
+      .public_fixedDataTableCell_main {
+        background: $cell-even-row-background-hover;
+      }
+    }
   }
 
   // scrollbar
@@ -79,10 +95,6 @@
         background-color: $scrollbar-color-hover;
       }
     }
-  }
-
-  .tablo-row:hover .public_fixedDataTableCell_main {
-    background: $cell-background-hover;
   }
 }
 

--- a/src/tablo/tabloVariables.scss
+++ b/src/tablo/tabloVariables.scss
@@ -22,6 +22,8 @@ $cell-border-color: $brc-silver !default;
 $cell-background-selected: #eaf4fd !default;
 $cell-background-hover: #f5fafe !default;
 $cell-background-hover-selected: $cell-background-hover !default;
+$cell-odd-row-background-hover: $cell-background-hover !default;
+$cell-even-row-background-hover: $cell-background-hover !default;
 
 $sortable-grid-arrows-opacity: .4 !default;
 $sortable-grid-arrows-opacity-hover: 1 !default;


### PR DESCRIPTION
Issue #760

## Test Plan

### tests performed
Settings the variables properly, now devs can do this
[![https://gyazo.com/ed6da6c61fc7e0bed8535531c3c514d9](https://i.gyazo.com/ed6da6c61fc7e0bed8535531c3c514d9.gif)](https://gyazo.com/ed6da6c61fc7e0bed8535531c3c514d9)