### PR TITLE
#762: Tablo: `Cell` should grow (closes #762)

### DIFF
--- a/src/tablo/Cell/Cell.js
+++ b/src/tablo/Cell/Cell.js
@@ -26,6 +26,7 @@ const template = ({
   color,
   vAlignContent = 'center',
   hAlignContent = 'left',
+  grow = true,
   style
 }) => {
   return (
@@ -33,6 +34,7 @@ const template = ({
       <FlexView
         className='tablo-cell'
         style={{ backgroundColor, color, ...style }}
+        grow={grow}
         vAlignContent={vAlignContent}
         hAlignContent={hAlignContent}
       >


### PR DESCRIPTION
Issue #762

## Test Plan

### tests performed
`Cell`
- should grow by default
- should be overridable