### PR TITLE
#771: Badge is overriding FlexVIew's `display` property (closes #771)

### DIFF
--- a/src/badge/badge.scss
+++ b/src/badge/badge.scss
@@ -9,7 +9,6 @@ $active-color: $brc-white !default;
 $active-background: $brc-gradientAzure !default;
 
 .badge {
-  display: inline-block;
   padding: $padding;
   border-radius: $border-radius;
   background: $background;


### PR DESCRIPTION
Issue #771

## Test Plan

### tests performed
![image](https://cloud.githubusercontent.com/assets/4029499/23025389/b89b1ffa-f455-11e6-8c44-ec49722897a8.png)

PS: it was working also before as in the showroom `flexView.css` is bundled after `badge.scss`


#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!
                              
- [x] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
