### PR TITLE
#727: Popover: debounced events are not canceled when component unmounts (closes #727)

### DIFF
--- a/src/popover/Popover.js
+++ b/src/popover/Popover.js
@@ -76,8 +76,12 @@ export default class Popover extends React.Component {
   componentWillUnmount() {
     this.removePopover();
     this.removeListeners();
-    this.onMouseEventDebouncedWhenOpen.cancel();
-    this.onMouseEventDebouncedWhenClosed.cancel();
+    if (this.onMouseEventDebouncedWhenOpen) {
+      this.onMouseEventDebouncedWhenOpen.cancel();
+    }
+    if (this.onMouseEventDebouncedWhenClosed) {
+      this.onMouseEventDebouncedWhenClosed.cancel();
+    }
 
   }
 
@@ -297,11 +301,11 @@ export default class Popover extends React.Component {
     const previousDelayWhenOpen = this.getDelayWhenOpen(previousDelay);
 
     if (!nextProps || previousDelayWhenClosed !== delayWhenClosed) {
-      this.onMouseEventDebouncedWhenClosed = debounce(this._onMouseEvent, delayWhenClosed);
+      this.onMouseEventDebouncedWhenClosed = delayWhenClosed ? debounce(this._onMouseEvent, delayWhenClosed) : null;
     }
 
     if (!nextProps || previousDelayWhenOpen !== delayWhenOpen) {
-      this.onMouseEventDebouncedWhenOpen = debounce(this._onMouseEvent, delayWhenOpen);
+      this.onMouseEventDebouncedWhenOpen = delayWhenOpen ? debounce(this._onMouseEvent, delayWhenOpen) : null;
     }
   };
 

--- a/src/popover/Popover.js
+++ b/src/popover/Popover.js
@@ -76,6 +76,9 @@ export default class Popover extends React.Component {
   componentWillUnmount() {
     this.removePopover();
     this.removeListeners();
+    this.onMouseEventDebouncedWhenOpen.cancel();
+    this.onMouseEventDebouncedWhenClosed.cancel();
+
   }
 
   // LISTENERS


### PR DESCRIPTION
Issue #727



### tests performed
* Go to popover > examples > hover.js
* Modify the example as follow:
```javascript
state = {
    renderPopover: true
  };
componentDidMount() {
    setTimeout(() => {
      this.setState({ renderPopover: false });
    }, 4000);
  }
```
* pass `delay={{ whenClosed: 5000 }}`, make sure the delaty of whenClosed > timeout set above
* Add the following:
```javascript
  return this.state.renderPopover ? (
      <Popover popover={popoverProps}>
        <FlexView hAlignContent='center' style={{ width: 150, border: '1px solid #dedede', padding: 10 }}>Hover me!</FlexView>
      </Popover>
    ) : <div>nope</div>;
```

* Run the application `npm run showroom`
* make sure the developertool is opened to see all the errors
* go to the popover component, and check if the error in the issue #727 is shown.


#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!
                              
- [x] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

