### PR TITLE
#784: Be compatible with `consistent-return` eslint rule  (closes #784)

### DIFF
--- a/src/loading-spinner/LoadingSpinner.js
+++ b/src/loading-spinner/LoadingSpinner.js
@@ -53,6 +53,7 @@ export default class LoadingSpinner extends React.Component {
         </div>
       );
     }
+    return undefined;
   };
 
   logWarnings = () => {
@@ -62,6 +63,7 @@ export default class LoadingSpinner extends React.Component {
       if (position !== 'relative' && position !== 'absolute') {
         return ['LoadingSpinner\'s parent node style should have "position: relative" or "position: absolute"', parentNode];
       }
+      return undefined;
     });
   };
 

--- a/src/meter/Meter.js
+++ b/src/meter/Meter.js
@@ -98,11 +98,13 @@ export default class Meter extends React.Component {
       if (isFullyFilled(ranges, min, max) && baseFillingColor) {
         return 'baseFillingColor not needed, ranges are fully filled';
       }
+      return undefined;
     });
     warn(() => {
       if (!(isFullyFilled(ranges, min, max) || baseFillingColor)) {
         return 'You should pass baseFillingColor, ranges are not fully filled';
       }
+      return undefined;
     });
   };
 

--- a/src/tablo/plugins/columnsReorder/columnsReorderGrid.js
+++ b/src/tablo/plugins/columnsReorder/columnsReorderGrid.js
@@ -62,8 +62,7 @@ export default (Grid) =>
         const target_index = list.indexOf(target);
         if (source_index <= target_index) {
           return [...list.slice(0, source_index), ...list.slice(source_index + 1, target_index + 1), source, ...list.slice(target_index + 1)];
-        }
-        if (target_index <= source_index) {
+        } else {
           return [...list.slice(0, target_index), source, ...list.slice(target_index, source_index), ...list.slice(source_index + 1)];
         }
       };
@@ -73,6 +72,7 @@ export default (Grid) =>
           const newColumnsOrder = moveColumn(orderedChildren.map(c => c.props.name), sourceName, targetName);
           return onColumnsReorder(newColumnsOrder);
         }
+        return undefined;
       };
 
       const isDragAllowed = ({ props: { fixed } }) => !fixed;

--- a/src/text-overflow/TextOverflow.js
+++ b/src/text-overflow/TextOverflow.js
@@ -58,6 +58,7 @@ export default class TextOverflow extends React.Component {
           return ['WARNING: TextOverflow\'s parent doesn\'t have "width: 100%" nor "flex-basis: 100%"', styleNode];
         }
       }
+      return undefined;
     });
   };
 


### PR DESCRIPTION
Closes #784

## Test Plan

### tests performed
- run `npm run lint` with `consistent-rule: 2`

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [ ] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
