### PR TITLE
#777: Tablo: scroll to selected row not working correctly (closes #777)

### DIFF
--- a/src/tablo/plugins/autosize/autosizeGrid.js
+++ b/src/tablo/plugins/autosize/autosizeGrid.js
@@ -52,7 +52,7 @@ export default (Grid) =>
 
       const content = (
         <FlexView grow column width='100%' ref='gridWrapper'>
-          <Grid {...tableProps} />
+          {tableProps.height > 0 && <Grid {...tableProps} />}
         </FlexView>
       );
 


### PR DESCRIPTION
Closes #777

## Test Plan

### tests performed
Add a `scrollToRow={0}` to the example:
- on master: tablo start with vertical scroll position > 0
- with this PR: tablo start with vertical sscroll position = 0

#### cross browser compatibility
- [x] ![Google Chrome](http://goo.gl/u4HnfV)
- [x] ![Internet Explorer](http://goo.gl/YqpZ4Z)
