### PR TITLE
add description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "buildo-react-components",
   "version": "0.13.2",
-  "description": "",
+  "description": "Collection of general React components used in buildo projects.",
   "main": "index.js",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
this info is exposed on yarnpkg.com, npmjs.com and others. If it's not filled in, the first part of the readme is used (which causes duplication of the badges)