### PR TITLE
#724: Dropdown: text color should not change on hover (closes #724)

### DIFF
--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -8,15 +8,15 @@ $border-color: $brc-silver !default;
 $border-color-open: $brc-waterBlue !default;
 $border-radius: 4px !default;
 $text-color: $brc-coolGrey !default;
-$text-color-hover: $brc-coolGrey !default;
 $text-color-open: $brc-coolGrey !default;
 $text-color-has-value: $brc-darkGrey !default;
+$text-color-hover: $text-color-has-value !default;
 $text-color-writing: $brc-coolGrey !default;
 $placeholder-color: #999 !default;
 $placeholder-color-hover: #666 !default;
 $placeholder-color-open: #666 !default;
 $arrow-color: $text-color !default;
-$arrow-color-hover: $text-color-hover !default;
+$arrow-color-hover: $text-color !default;
 $arrow-color-open: $text-color-open !default;
 $x-color: $text-color !default;
 $x-color-hover: $brc-red !default;
@@ -226,7 +226,7 @@ $height-small: 30px !default;
     }
   }
 
-  &:not(.is-disabled):not(.has-value):hover {
+  &:not(.is-disabled):hover {
     background: $background-hover;
 
     .Select-control .Select-value .Select-value-label {

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -226,7 +226,7 @@ $height-small: 30px !default;
     }
   }
 
-  &:not(.is-disabled):hover {
+  &:not(.is-disabled):not(.has-value):hover {
     background: $background-hover;
 
     .Select-control .Select-value .Select-value-label {


### PR DESCRIPTION
Closes #724 

**test plan**

- Go to dropDown menu component
- Try to select one of the options in one of the dropDown menu
- Hover over the dropdown, the text color of the **SELECTED VALUE** should **NOT** be changed, as the attached gif:

![cksrp6lsoj](https://cloud.githubusercontent.com/assets/22367312/23501657/ffc611ac-ff34-11e6-8207-240c062c16ea.gif)

