### PR TITLE
#753: Meter: ranges should have a default value (closes #753)

### DIFF
--- a/src/meter/Meter.js
+++ b/src/meter/Meter.js
@@ -48,6 +48,9 @@ export const Props = t.refinement(t.struct({
 }), ({ min, max }) => min < max, 'Props');
 
 const isFullyFilled = (ranges, min, max) => {
+  if (!ranges) {
+    return false;
+  }
   const comparableRanges = ranges.concat({ startValue: max, endValue: min });
   const sortedStartValueList = sortBy(comparableRanges, 'startValue').map(range => range.startValue);
   const sortedEndValueList = sortBy(comparableRanges, 'endValue').map(range => range.endValue);
@@ -80,8 +83,7 @@ export default class Meter extends React.Component {
   static defaultProps = {
     min: 0,
     max: 100,
-    labelFormatter,
-    ranges: []
+    labelFormatter
   };
 
   componentDidMount() {

--- a/src/meter/Meter.js
+++ b/src/meter/Meter.js
@@ -95,17 +95,18 @@ export default class Meter extends React.Component {
       ranges,
       max,
       min,
-      baseFillingColor
+      baseFillingColor,
+      baseBackgroundColor
     } = this.props;
     warn(() => {
-      if (isFullyFilled(ranges, min, max) && baseFillingColor) {
-        return 'baseFillingColor not needed, ranges are fully filled';
+      if (isFullyFilled(ranges, min, max) && (baseFillingColor || baseBackgroundColor)) {
+        return 'baseFillingColor or baseBackgroundColor is not needed, ranges are fully filled';
       }
       return undefined;
     });
     warn(() => {
-      if (!(isFullyFilled(ranges, min, max) || baseFillingColor)) {
-        return 'You should pass baseFillingColor, ranges are not fully filled';
+      if (!(isFullyFilled(ranges, min, max) || (baseFillingColor && baseBackgroundColor))) {
+        return 'You should pass both baseFillingColor and baseBackgroundColor, ranges are not fully filled';
       }
       return undefined;
     });

--- a/src/meter/Meter.js
+++ b/src/meter/Meter.js
@@ -80,7 +80,8 @@ export default class Meter extends React.Component {
   static defaultProps = {
     min: 0,
     max: 100,
-    labelFormatter
+    labelFormatter,
+    ranges: []
   };
 
   componentDidMount() {

--- a/src/meter/examples/customLabels.js
+++ b/src/meter/examples/customLabels.js
@@ -16,7 +16,7 @@ class Example extends React.Component {
 
     const ranges = [
       { startValue: 400, endValue: 665, fillingColor: '#34aa44', labelColor: '#34aa44' },
-      { startValue: 666, endValue: 667, fillingColor: '#ed1c24', labelColor: '#ed1c24' },
+      { startValue: 665, endValue: 667, fillingColor: '#ed1c24', labelColor: '#ed1c24' },
       { startValue: 667, endValue: 700, fillingColor: '#fdc018', labelColor: '#fdc018' }
     ];
 


### PR DESCRIPTION
Closes #753

## Test Plan

### tests performed
* In the examples/default.js, change the passed properties to (remove ranges, and add baseFillingColor)
const meterProps = {
      style: { marginBottom: 20 },
      baseFillingColor: 'brown'
   };

No errors should be shown in the console.

* If a warning message with "You should pass baseFillingColor, ranges are not fully filled"
In the example file of customLabel.js, make sure to add the "baseFillingColor" property to make the warning disappears. 

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [ ] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
