### PR TITLE
#794: add the ability to pass custom React context to Modal render tree (closes #794)

### DIFF
--- a/showroom/components.json
+++ b/showroom/components.json
@@ -213,6 +213,11 @@
           {
             "title": "Modal without footer",
             "url": "modal/examples/noFooter.js"
+          },
+          {
+            "title": "Passing arbitrary React context",
+            "description": "Modal renders through a \"portal\", so React context is not propagated as expected.<br><br>*We know context isn't a public api, but it is required for <a href=\"https://github.com/reactjs/react-redux\">widely</a> <a href=\"https://github.com/yahoo/react-intl\">used</a> libraries to work. We also know there's `renderSubtreeIntoContainer`, which is unfortunately even more unstable.*<br/><br/>To solve this problem we export a handy `modalWithContext` that easily allows to pass context down correctly (look at the code!).",
+            "url": "modal/examples/withContext.js"
           }
         ]
       },

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ export { linkState, getValueLink, LinkedStateMixin, ValueLinkMixin } from './lin
 export ScrollView from './ScrollView/ScrollView';
 export { Toaster, TimerToast } from './toaster';
 export { ModalManager, BasicModal } from './modal-manager';
-export Modal from './modal';
+export Modal, { modalWithContext } from './modal';
 export TransitionWrapper from './transition-wrapper';
 export BackgroundDimmer from './background-dimmer';
 export Divider from './Divider';

--- a/src/modal/Modal.js
+++ b/src/modal/Modal.js
@@ -37,7 +37,7 @@ export const Props = {
  * @param onDismiss - called when modal is dismissed
  * @param transitionEnterTimeout - transition enter timeout
  * @param transitionLeaveTimeout - transition leave timeout
- * @param childContextTypes: context types to pass to the modal React tree,
+ * @param childContextTypes: context types to pass to the modal React tree
  * @param getChildContext: should return context values to pass to the modal React tree
  */
 @skinnable()

--- a/src/modal/Modal.js
+++ b/src/modal/Modal.js
@@ -37,6 +37,8 @@ export const Props = {
  * @param onDismiss - called when modal is dismissed
  * @param transitionEnterTimeout - transition enter timeout
  * @param transitionLeaveTimeout - transition leave timeout
+ * @param childContextTypes: context types to pass to the modal React tree,
+ * @param getChildContext: should return context values to pass to the modal React tree
  */
 @skinnable()
 @props(Props)

--- a/src/modal/ModalPortal.js
+++ b/src/modal/ModalPortal.js
@@ -4,26 +4,34 @@ import ReactTransitionGroup from 'react-addons-transition-group';
 import { props, t } from '../utils';
 import TransitionWrapper from '../transition-wrapper';
 
-class ContextWrapper extends React.Component {
-  getChildContext = () => this.props.context;
-  render = () => this.props.modal();
-}
-
 let containerNode = null;
 
 export const Props = {
   children: t.ReactChildren,
   transitionEnterTimeout: t.Number,
   transitionLeaveTimeout: t.Number,
-  className: t.maybe(t.String)
+  className: t.maybe(t.String),
+  childContextTypes: t.maybe(t.Object),
+  getChildContext: t.maybe(t.Function)
 };
 
 @props(Props)
-export default class ModalPortal extends React.Component { // eslint-disable-line react/no-multi-comp
+export default class ModalPortal extends React.Component {
 
   render() {
     return null;
   }
+
+  _ContextWrapper = (() => {
+    const childContextTypes = this.props.childContextTypes || {};
+    return class ContextWrapper extends React.Component { // eslint-disable-line react/no-multi-comp
+      static childContextTypes = childContextTypes;
+      getChildContext = this.props.getChildContext || (() => ({}));
+      render() {
+        return this.props.modal();
+      }
+    };
+  })();
 
   componentDidMount() {
     this.isOpen = true;
@@ -55,8 +63,9 @@ export default class ModalPortal extends React.Component { // eslint-disable-lin
       document.body.appendChild(containerNode);
     }
 
-    const Modal = this._renderModal();
-    ReactDOM.render(<ContextWrapper modal={Modal} />, containerNode);
+    const modal = this._renderModal();
+    const ContextWrapper = this._ContextWrapper;
+    ReactDOM.render(<ContextWrapper modal={modal} />, containerNode);
   }
 
   _renderModal() {

--- a/src/modal/README.md
+++ b/src/modal/README.md
@@ -9,6 +9,8 @@ Render a modal window over a dimmed layer
 | **transitionEnterTimeout** | <code>Number</code> |  | **required**. Transition enter timeout |
 | **transitionLeaveTimeout** | <code>Number</code> |  | **required**. Transition leave timeout |
 | **className** | <code>String</code> |  | *optional*. Additional `className` for wrapper element |
+| **childContextTypes** | <code>Object</code> |  | *optional*. : context types to pass to the modal React tree |
+| **getChildContext** | <code>Function</code> |  | *optional*. : should return context values to pass to the modal React tree |
 | **title** | <code>String</code> |  | *optional*. Modal title |
 | **footer** | <code>ReactChildren</code> |  | *optional*. Modal footer |
 | **iconClose** | <code>ReactChildren</code> |  | *optional*. Close icon |

--- a/src/modal/examples/withContext.js
+++ b/src/modal/examples/withContext.js
@@ -1,0 +1,54 @@
+const FooType = React.PropTypes.string.isRequired;
+
+const ModalWithContext = modalWithContext({ foo: FooType });
+
+class ComponentAccessingContext extends React.Component {
+  static contextTypes = {
+    foo: FooType
+  };
+
+  render() {
+    return <div>{this.context.foo}</div>;
+  }
+}
+
+class Example extends React.Component {
+  static childContextTypes = {
+    foo: FooType
+  };
+
+  getChildContext = () => ({
+    foo: 'this comes from context!'
+  });
+
+  state = { isOpen: false };
+
+  open = () => this.setState({ isOpen: true })
+
+  close = () => this.setState({ isOpen: false })
+
+  getModal = () => (
+    <ModalWithContext
+      transitionEnterTimeout={500}
+      transitionLeaveTimeout={500}
+      onDismiss={this.close}
+      iconClose={<Icon icon='close' />}
+      title='Send Message'
+      footer={
+        <FlexView hAlignContent='right'>
+          <Button default size='small' style={{ marginRight: 10 }} onClick={this.close}>Cancel</Button>
+          <Button primary size='small' onClick={this.close}>Confirm</Button>
+        </FlexView>
+      }
+    >
+      <ComponentAccessingContext />
+    </ModalWithContext>
+  )
+
+  render = () => (
+    <div>
+      <Button default onClick={this.open}>Open modal</Button>
+      {this.state.isOpen && this.getModal()}
+    </div>
+  )
+}

--- a/src/modal/index.js
+++ b/src/modal/index.js
@@ -1,1 +1,2 @@
 export default from './Modal';
+export { modalWithContext } from './modalWithContext';

--- a/src/modal/modalWithContext.js
+++ b/src/modal/modalWithContext.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import Modal from './Modal';
+
+export const modalWithContext = contextTypes =>
+  class ContextWrapper extends React.Component {
+    static contextTypes = contextTypes;
+
+    render() {
+      const contextProps = {
+        childContextTypes: contextTypes,
+        getChildContext: () => this.context
+      };
+      return <Modal {...this.props} {...contextProps} />;
+    }
+  };

--- a/test/components/Modal.test.js
+++ b/test/components/Modal.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { modalWithContext } from '../../src/modal';
+
+describe('Modal', () => {
+
+  it('should correctly pass context down if used via modalWithContext', () => {
+    // `.isRequired` makes the test fail if context is not provided
+    const FooType = React.PropTypes.string.isRequired;
+    const ComponentAccessingContext = (_, ctx) => <div>{ctx.foo}</div>;
+    ComponentAccessingContext.contextTypes = { foo: FooType };
+    const ModalPassingContext = modalWithContext({ foo: FooType });
+    mount(
+      <ModalPassingContext
+        transitionEnterTimeout={0}
+        transitionLeaveTimeout={0}
+      >
+        <ComponentAccessingContext />
+      </ModalPassingContext>,
+      { context: { foo: 'bar' } }
+    );
+  });
+
+});


### PR DESCRIPTION
Closes #794

## Test Plan

### tests performed

tested manually on gdsm using
```js
import { modalWithContext } from 'buildo-react-components/lib/modal';
import { intlShape } from 'react-intl';

import './modal.scss';

export default modalWithContext({ intl: intlShape });
```

and adding `@intlMethods` on a component rendered inside the modal

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [x] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
