### PR TITLE
#796: Dropdown should allow to pass simpleValue=false (closes #796)

### DIFF
--- a/src/dropdown/Dropdown.js
+++ b/src/dropdown/Dropdown.js
@@ -24,6 +24,7 @@ export const Props = {
   multi: t.maybe(t.Boolean),
   flat: t.maybe(t.Boolean),
   autoBlur: t.maybe(t.Boolean),
+  simpleValue: t.maybe(t.Boolean),
   id: t.maybe(t.String),
   className: t.maybe(t.String),
   style: t.maybe(t.Object)
@@ -42,6 +43,7 @@ export const Props = {
  * @param multi - true if it should be possible to select multiple values
  * @param flat - whether it should have a flat style
  * @param autoBlur - whether it should blur automatically when the user selects a value
+ * @param simpleValue - if true, selected values will be passed to onChange as comma-separated string of values (eg "1,2,3") instead of array of objects
  */
 @skinnable()
 @props(Props, { strict: false })
@@ -55,7 +57,8 @@ export default class Dropdown extends React.Component {
     clearable: false,
     multi: false,
     flat: false,
-    autoBlur: true
+    autoBlur: true,
+    simpleValue: true
   }
 
   componentDidMount() {
@@ -125,7 +128,6 @@ export default class Dropdown extends React.Component {
       clearable,
       backspaceRemoves: t.Nil.is(backspaceRemoves) ? clearable : backspaceRemoves,
       resetValue: null,
-      simpleValue: true,
       className: cx('dropdown', className, this.getCustomClassNames()),
       value: this.valueToOption(this.getValue(), options),
       onInputKeyDown,

--- a/src/dropdown/README.md
+++ b/src/dropdown/README.md
@@ -17,6 +17,7 @@ A dropdown field based on [react-select](https://github.com/JedWatson/react-sele
 | **multi** | <code>Boolean</code> | <code>false</code> | *optional*. True if it should be possible to select multiple values |
 | **flat** | <code>Boolean</code> | <code>false</code> | *optional*. Whether it should have a flat style |
 | **autoBlur** | <code>Boolean</code> | <code>true</code> | *optional*. Whether it should blur automatically when the user selects a value |
+| **simpleValue** | <code>Boolean</code> | <code>true</code> | *optional*. If true, selected values will be passed to onChange as comma-separated string of values (eg "1,2,3") instead of array of objects |
 | **id** | <code>String</code> |  | *optional*. Custom `id` for wrapper element |
 | **className** | <code>String</code> |  | *optional*. Additional `className` for wrapper element |
 | **style** | <code>Object</code> |  | *optional*. Inline-style overrides for wrapper element |


### PR DESCRIPTION
Closes #796

## Test Plan

### tests performed
- dropdown in showroom still works as expected (selected value is a string)
- adding `simpleValue={false}`, value will be passed to `onChange` as an object

![](https://i.gyazo.com/917ea2a401b4fefd27c4e847100a1599.gif)

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [x] ![Google Chrome](http://goo.gl/u4HnfV)
- [x] ![Internet Explorer](http://goo.gl/YqpZ4Z)