### PR TITLE
#817: AsyncStatusIndicator should export `SavingState` model (closes #817)

### DIFF
--- a/src/async-status-indicator/AsyncStatusIndicator.js
+++ b/src/async-status-indicator/AsyncStatusIndicator.js
@@ -3,7 +3,7 @@ import { pure, skinnable, props, t } from '../utils';
 import cx from 'classnames';
 import View from 'react-flexview';
 
-const AsyncStatusIndicatorState = t.enums.of([
+export const AsyncStatusIndicatorState = t.enums.of([
   'ready',
   'processing',
   'success',

--- a/src/async-status-indicator/index.js
+++ b/src/async-status-indicator/index.js
@@ -1,2 +1,4 @@
-import AsyncStatusIndicator from './AsyncStatusIndicator';
+import AsyncStatusIndicator, { Props as AsyncStatusIndicatorProps, AsyncStatusIndicatorState } from './AsyncStatusIndicator';
+
+export { AsyncStatusIndicatorProps, AsyncStatusIndicatorState };
 export default AsyncStatusIndicator;


### PR DESCRIPTION
Closes #817

## Test Plan

### tests performed
* install locally the react-components to  alinityPro project to test. 
* In alinityPro project use the exported AsyncStatusIndicatorState in: 
src/app/components/Basic/AsyncStatusIndicator/AsyncStatusIndicator.js
export { AsyncStatusIndicatorState as SavingState } from 'buildo-react-components/lib/async-status-indicator';
* make sure the async status is still working.

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [ ] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
