### PR TITLE
#827: dropdown:`Select-multi-value-wrapper` should be vertically centered (closes #827)

### DIFF
--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -238,8 +238,8 @@ $height-small: 30px !default;
 
     &.has-value .Select-control .Select-value {
       margin-right: 5px;
-      margin-top: auto;
-      margin-bottom: auto;
+      margin-top: 5px;
+      margin-bottom: 5px;
       border: 1px solid $multiple-value-border-color;
 
       @include height($height - 14px);

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -232,42 +232,65 @@ $height-small: 30px !default;
       }
     }
 
-    &.has-value .Select-input {
-      position: relative;
-    }
+    &.has-value {
+      .Select-control {
+        .Select-multi-value-wrapper {
+          padding: 2px 0;
 
-    &.has-value .Select-control .Select-value {
-      margin-right: 5px;
+          .Select-input {
+            position: relative;
 
-      /*
-        vertical margin is needed to add some space between values when they wrap.
-        5px is not random: 10px is the gap to match .Select-input in height and avoid visual defects
-      */
-      margin-top: 5px;
-      margin-bottom: 5px;
-      border: 1px solid $multiple-value-border-color;
+            @include height($height - 12px);
 
-      @include height($height - 14px);
+            > input {
+              @include height($height - 12px);
+            }
+          }
 
-      .Select-value-label {
-        @include height($height - 14px);
+          .Select-value {
+            margin-right: 5px;
 
-        background: $multiple-value-background-color;
-        color: $multiple-value-color;
-        padding-top: 0;
-        padding-bottom: 0;
+            /*
+              vertical margin is needed to add some space between values when they wrap.
+              5px is not random: 10px is the gap to match .Select-input in height and avoid visual defects
+            */
+            margin-top: 2px;
+            margin-bottom: 2px;
+            border: 1px solid $multiple-value-border-color;
+
+            @include height($height - 14px);
+
+            .Select-value-label {
+              @include height($height - 14px);
+
+              background: $multiple-value-background-color;
+              color: $multiple-value-color;
+              padding-top: 0;
+              padding-bottom: 0;
+            }
+
+            .Select-value-icon {
+              padding: 0 4px;
+              border-color: $multiple-value-icon-border-color;
+              background: $multiple-value-icon-background-color;
+              color: $multiple-value-icon-color;
+
+              &:hover {
+                border-color: $multiple-value-icon-border-color-hover;
+                background: $multiple-value-icon-background-color-hover;
+                color: $multiple-value-icon-color-hover;
+              }
+            }
+          }
+        }
       }
 
-      .Select-value-icon {
-        padding: 0 4px;
-        border-color: $multiple-value-icon-border-color;
-        background: $multiple-value-icon-background-color;
-        color: $multiple-value-icon-color;
-
-        &:hover {
-          border-color: $multiple-value-icon-border-color-hover;
-          background: $multiple-value-icon-background-color-hover;
-          color: $multiple-value-icon-color-hover;
+      &.is-small {
+        .Select-control .Select-multi-value-wrapper {
+          .Select-input,
+          .Select-input > input {
+            @include height($height-small - 12px);
+          }
         }
       }
     }

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -121,7 +121,7 @@ $height-small: 30px !default;
 
     .Select-multi-value-wrapper {
       @include flex_flex-wrap(wrap);
-      @include flex_align-items(stretch);
+      @include flex_align-items(center);
     }
 
     .Select-input {

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -241,7 +241,7 @@ $height-small: 30px !default;
 
       /*
         vertical margin is needed to add some space between values when they wrap.
-        5px is not random: 10px is the gap to match .combobox in height and avoid visual defects
+        5px is not random: 10px is the gap to match .Select-input in height and avoid visual defects
       */
       margin-top: 5px;
       margin-bottom: 5px;

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -274,6 +274,10 @@ $height-small: 30px !default;
 
     &.is-small .Select-control .Select-value {
       @include height($height-small - 14px);
+
+      .Select-value-label {
+        @include height($height-small - 14px);
+      }
     }
   }
 

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -238,6 +238,11 @@ $height-small: 30px !default;
 
     &.has-value .Select-control .Select-value {
       margin-right: 5px;
+
+      /*
+        vertical margin is needed to add some space between values when they wrap.
+        5px is not random: 10px is the gap to match .combobox in height and avoid visual defects
+      */
       margin-top: 5px;
       margin-bottom: 5px;
       border: 1px solid $multiple-value-border-color;


### PR DESCRIPTION
Closes #827

## Test Plan

### tests performed

multi values centered:
![image](https://cloud.githubusercontent.com/assets/4029499/24350736/9e2f5918-12e3-11e7-80ac-3516ae579ae0.png)

multi values centered and well spaced when wrapping:
![image](https://cloud.githubusercontent.com/assets/4029499/24350749/aa19b458-12e3-11e7-9736-baa6758ad516.png)

size "small":
![image](https://cloud.githubusercontent.com/assets/4029499/24350722/90173f76-12e3-11e7-8a96-bb1436a556ea.png)


#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [x] ![Google Chrome](http://goo.gl/u4HnfV)
- [x] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
