### PR TITLE
#831: Add touchScrollEnabled prop to Tablo component (closes #831)

### DIFF
--- a/src/tablo/API.md
+++ b/src/tablo/API.md
@@ -5,7 +5,7 @@ A table component based on fixed-data-table-2
 ## Props
 |Name|Type|Default|Description|
 |----|----|-------|-----------|
-| **data** | <code>Array(Object)</code> |  | **required**. Data shown in the table. It must be an array of structs of the samey types |
+| **data** | <code>Array(Object)</code> |  | **required**. Data shown in the table. It must be an array of structs of the same types |
 | **autosize** | <code>Boolean</code> | <code>true</code> | *optional*. Whether the table should fit the container sizes or not. If set to <code>false</code>, <code>width</code> and <code>height</code> must be provided
 | **columnsOrder** | <code>Array(String)</code> | | *optional*. An optional reordering of the columns. An array with the columns' names must be provided. To be used together with <code>onColumnsReorder</code> to handle dynamically the reordering of the columns
 | **onColumnsReorder** | <code>Function</code> | | *optional*. Callback to handle the reordering of the columns. The new <code>columnsOrder</code> is passed as parameter.
@@ -29,6 +29,7 @@ A table component based on fixed-data-table-2
 | **onScrollEnd** | <code>Function</code> |  | *optional*. Callback to be called when scrolling ends |
 | **children** | <code>ReactChildren</code> |  | *optional*. Table children (Column or ColumnGroup). If left undefined, columns will be populated automatically with data|
 | **rowClassNameGetter** | <code>Function</code> |  | *optional*. Function: <code>(index) => className</code> of row of index <code>index</code>|
+| **touchScrollEnabled** | <code>Boolean</code> |   | *optional*. Enable touch scroll
 
 ## Column Props
 |Name|Type|Default|Description|

--- a/src/tablo/README.md
+++ b/src/tablo/README.md
@@ -21,6 +21,7 @@ A table component based on fixed-data-table-2
 | **onScrollEnd** | <code>Function</code> |  | *optional*. Callback to be called when scrolling ends |
 | **children** | <code>ReactChildren</code> |  | **required**. Table children (Column or ColumnGroup) |
 | **rowClassNameGetter** | <code>Function</code> | <code>"rowClassNameGetter"</code> | *optional*. A function index -> className |
+| **touchScrollEnabled** | <code>Boolean</code> |  | *optional*. Enable touch scroll |
 | **scrollToRow** | <code>Integer</code> |  | *optional*. Private |
 | **onRowClick** | <code>Function</code> |  | *optional*. Private |
 | **onColumnResizeEndCallback** | <code>Function</code> |  | *optional*. Private |

--- a/src/tablo/Tablo.js
+++ b/src/tablo/Tablo.js
@@ -37,7 +37,7 @@ const { maybe } = t;
  * @param sortDir - sorting direction
  * @param onSortChange - callback to be called when sorting change
  * @param rowClassNameGetter - a function index -> className
-
+ * @param touchScrollEnabled - enable touch scroll
  *
  * @param scrollToRow - Private
  * @param onRowClick - Private
@@ -64,6 +64,7 @@ const { maybe } = t;
   onScrollEnd: maybe(t.Function),
   children: t.ReactChildren,
   rowClassNameGetter: maybe(t.Function),
+  touchScrollEnabled: maybe(t.Boolean),
 
   // private
   scrollToRow: maybe(t.Integer),


### PR DESCRIPTION
Closes #831

## Test Plan

### tests performed
- table scrolls with touch events ✅ 
- tap on desired position in scrollbars lane trigger a scroll in the desired position (just a little bit slow) ✅ 

Things to be noticed:
- dragging scrollbar cause a scroll in the opposite direction of touch gesture 

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [ ] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
