### PR TITLE
#830: Dropdown: on IE11, values in multi-select mode are not vertically aligned when in single line (closes #830)

### DIFF
--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -221,7 +221,14 @@ $height-small: 30px !default;
       height: auto;
 
       .Select-multi-value-wrapper {
+        min-height: $height;
         height: auto;
+      }
+    }
+
+    &.is-small {
+      .Select-multi-value-wrapper {
+        min-height: $height-small;
       }
     }
 
@@ -229,6 +236,7 @@ $height-small: 30px !default;
       .Select-control {
         .Select-multi-value-wrapper {
           padding: 2px 0;
+          min-height: auto;
 
           .Select-input {
             position: relative;
@@ -280,6 +288,8 @@ $height-small: 30px !default;
 
       &.is-small {
         .Select-control .Select-multi-value-wrapper {
+          min-height: auto;
+
           .Select-input,
           .Select-input > input {
             @include height($height-small - 12px);

--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -221,14 +221,7 @@ $height-small: 30px !default;
       height: auto;
 
       .Select-multi-value-wrapper {
-        min-height: $height;
         height: auto;
-      }
-    }
-
-    &.is-small {
-      .Select-multi-value-wrapper {
-        min-height: $height-small;
       }
     }
 


### PR DESCRIPTION
Closes #830

### tests performed
* In IE11, test the default size dropdown:
![image](https://cloud.githubusercontent.com/assets/22367312/24510604/fe61e89a-1569-11e7-9af3-32722ea62892.png)
* Add more options till they wrap to next line:
![image](https://cloud.githubusercontent.com/assets/22367312/24510641/1c6b55d8-156a-11e7-8ac7-c84af1e2d50c.png)

*Change the size of the dropdown in the multi example by adding the property `size='small'`, in IE11
![image](https://cloud.githubusercontent.com/assets/22367312/24510826/8d73ddae-156a-11e7-8fc4-4c2153674e98.png)

*Continue adding options till they wrapped to  new line:
![image](https://cloud.githubusercontent.com/assets/22367312/24510868/a75db3de-156a-11e7-9093-1bc059ca258e.png)

* Add the property searchable to dropdown and test the dropdown
![upvphrcmj1](https://cloud.githubusercontent.com/assets/22367312/24515155/ff876094-1576-11e7-867c-bf5d51ce5cec.gif)


Repeat the steps above in Chrome, and make sure everything is working.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [x] ![Google Chrome](http://goo.gl/u4HnfV)
- [x] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
