### PR TITLE
#842: Tablo: resizing plugin should be disabled if onColumnsResize is missing (closes #842)

### DIFF
--- a/src/tablo/plugins/columnsResize/columnsResizeGrid.js
+++ b/src/tablo/plugins/columnsResize/columnsResizeGrid.js
@@ -15,11 +15,17 @@ const addSizeProps = ({ col }) => ( //eslint-disable-line
 
 const propsTypes = {
   className: maybe(t.String),
-  onColumnResize: t.Function,
+  onColumnResize: maybe(t.Function),
   children: maybe(t.ReactChildren)
 };
 
-const getLocals = ({ className, children, onColumnResize, ...gridProps }) => {
+const getLocals = (props) => {
+  const { className, children, onColumnResize, ...gridProps } = props;
+
+  // if `onColumnResize` is missing bypass this plugin
+  if (!onColumnResize) {
+    return props;
+  }
 
   const onColumnResizeEndCallback = (width, key) => {
     onColumnResize({ width, key });


### PR DESCRIPTION
Closes #842

## Test Plan

### tests performed
tested on QIA about this issue: https://github.omnilab.our.buildo.io/buildo/aliniq/issues/5114

- pass onColumnResize -> resize enabled and working, tcomb doesn't complain ✅ 
- pass `onColumnResize: undefined` -> resize disable, tcomb doesn't complain ✅ 

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [x] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
