### PR TITLE
#844: Tablo: never pass onColumnResize down directly (closes #844)

### DIFF
--- a/src/tablo/plugins/columnsResize/columnsResizeGrid.js
+++ b/src/tablo/plugins/columnsResize/columnsResizeGrid.js
@@ -19,13 +19,14 @@ const propsTypes = {
   children: maybe(t.ReactChildren)
 };
 
-const getLocals = (props) => {
-  const { className, children, onColumnResize, ...gridProps } = props;
+const getLocals = ({ onColumnResize, ...props }) => {
 
   // if `onColumnResize` is missing bypass this plugin
   if (!onColumnResize) {
     return props;
   }
+
+  const { className, children, ...gridProps } = props;
 
   const onColumnResizeEndCallback = (width, key) => {
     onColumnResize({ width, key });


### PR DESCRIPTION
Closes #844

## Test Plan

### tests performed
this commit was meant to be pushed on #843 , the test plan is the same

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [ ] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
