### PR TITLE
#848: add `onInputChange`, `onBlur` and `onFocus` to Dropdown proptypes (closes #848)

### DIFF
--- a/src/dropdown/Dropdown.js
+++ b/src/dropdown/Dropdown.js
@@ -42,6 +42,9 @@ export const Props = {
   valueRenderer: t.maybe(t.Function),
   optionRenderer: t.maybe(t.Function),
   delimiter: t.maybe(t.String),
+  onInputChange: t.maybe(t.Function),
+  onFocus: t.maybe(t.Function),
+  onBlur: t.maybe(t.Function),
   id: t.maybe(t.String),
   className: t.maybe(t.String),
   style: t.maybe(t.Object)
@@ -72,6 +75,9 @@ export const Props = {
  * @param allowCreate - whether it should be possible to create new options
  * @param addLabelText - if allowCreate is true, message shown to hint the user to press Enter to create a new option
  * @param delimiter - if multi is true, string used to separate selected values
+ * @param onFocus - called when dropdown is focused
+ * @param onBlur - called when dropdown is blurred
+ * @param onInputChange - called when the value of the `input` is changed
  */
 @skinnable()
 @props(Props, { strict: true })

--- a/src/dropdown/Dropdown.js
+++ b/src/dropdown/Dropdown.js
@@ -32,9 +32,6 @@ export const Props = {
   autoBlur: t.maybe(t.Boolean),
   simpleValue: t.maybe(t.Boolean),
   menuPosition: t.maybe(t.enums.of(['top', 'bottom'])),
-  id: t.maybe(t.String),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object),
   menuRenderer: t.maybe(t.Function),
   groupByKey: t.maybe(t.String),
   optionGroupRenderer: t.maybe(t.Function),
@@ -44,7 +41,10 @@ export const Props = {
   addLabelText: t.maybe(t.String),
   valueRenderer: t.maybe(t.Function),
   optionRenderer: t.maybe(t.Function),
-  delimiter: t.maybe(t.String)
+  delimiter: t.maybe(t.String),
+  id: t.maybe(t.String),
+  className: t.maybe(t.String),
+  style: t.maybe(t.Object)
 };
 
 /** A dropdown field based on [react-select](https://github.com/JedWatson/react-select)


### PR DESCRIPTION
Closes #848

## Test Plan

### tests performed
- `npm start`
- pass the new props to a dropdown
  - no tcomb error in console
  - the three cb work correctly

![image](https://cloud.githubusercontent.com/assets/4029499/24660909/1d3feae2-1951-11e7-87b5-07f64270fdfc.png)


#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [ ] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
