### PR TITLE
#850: Dropdown: no style for focus (closes #850)

### DIFF
--- a/src/dropdown/dropdown.scss
+++ b/src/dropdown/dropdown.scss
@@ -6,6 +6,7 @@ $background-hover: $brc-gradientDarkGrey !default;
 $background-open: $brc-gradientDarkGrey !default;
 $border-color: $brc-silver !default;
 $border-color-open: $brc-waterBlue !default;
+$border-color-focus: $brc-waterBlue !default;
 $border-radius: 4px !default;
 $text-color: $brc-coolGrey !default;
 $text-color-open: $brc-coolGrey !default;
@@ -104,6 +105,10 @@ $height-small: 30px !default;
   color: $text-color;
   font-size: 15px;
   font-weight: 400;
+
+  &:not(.is-disabled).is-focused {
+    border-color: $border-color-focus;
+  }
 
   .Select-control {
     padding-left: 10px;


### PR DESCRIPTION
Closes #850

## Test Plan

### tests performed
- when focused hitting TAB
![](https://i.gyazo.com/5d5985d3f2f4c0d642a5d9d619934772.gif)

- when disabled, border doesn't change on focus

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [x] ![Google Chrome](http://goo.gl/u4HnfV)
- [x] ![Internet Explorer](http://goo.gl/YqpZ4Z)
