### PR TITLE
#852: Tablo: cell content is not vertically centered in Safari (closes #852)

### DIFF
--- a/src/tablo/Cell/Cell.js
+++ b/src/tablo/Cell/Cell.js
@@ -42,7 +42,6 @@ const template = ({
         <FlexView
           className='content'
           grow={grow}
-          height='100%'
           vAlignContent={vAlignContent}
           hAlignContent={hAlignContent}
         >


### PR DESCRIPTION
Closes #852

## Test Plan

### tests performed
- Firefox
<img width="1677" alt="screen shot 2017-04-05 at 11 37 33" src="https://cloud.githubusercontent.com/assets/1838567/24699463/5404e8cc-19f4-11e7-8bfd-aad05bf01fb3.png">


- Safari
<img width="948" alt="screen shot 2017-04-05 at 11 33 46" src="https://cloud.githubusercontent.com/assets/1838567/24699357/024fde6a-19f4-11e7-81bd-5afcafb4eb46.png">

- Google Chrome
<img width="1663" alt="screen shot 2017-04-05 at 11 33 57" src="https://cloud.githubusercontent.com/assets/1838567/24699356/024fb00c-19f4-11e7-9380-ad487f42ee64.png">

- IE
![virtualbox_ie11 - win8 1_05_04_2017_11_33_14](https://cloud.githubusercontent.com/assets/1838567/24699392/19e6e2f8-19f4-11e7-99a4-db13d9a74291.png)

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [ ] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
