### PR TITLE
#836: dropDownMenu: clicking near a menu item may close the menu without calling the item's action (closes #836)

### DIFF
--- a/src/DropdownMenu/DropdownMenu.js
+++ b/src/DropdownMenu/DropdownMenu.js
@@ -124,10 +124,12 @@ export default class DropdownMenu extends React.Component {
 
   template({ iconClassName, toggleMenu, children, options, isOpen, dismissOnClickOut, className, onMenuClick, height }) {
     return (
-      <FlexView vAlignContent='center' className={cx('dropdown-menu', className)} onClick={toggleMenu}>
+      <FlexView>
         {this.templateOverlay({ isOpen, toggleMenu, dismissOnClickOut })}
-        {this.templateToggler({ children, iconClassName, toggleMenu, isOpen })}
-        {this.templateMenu({ isOpen, options, height, toggleMenu, onMenuClick })}
+        <FlexView vAlignContent='center' className={cx('dropdown-menu', className)} onClick={toggleMenu}>
+          {this.templateToggler({ children, iconClassName, toggleMenu, isOpen })}
+          {this.templateMenu({ isOpen, options, height, toggleMenu, onMenuClick })}
+        </FlexView>
       </FlexView>
     );
   }

--- a/src/DropdownMenu/dropdownMenu.scss
+++ b/src/DropdownMenu/dropdownMenu.scss
@@ -37,5 +37,6 @@ $icon-color-hover: $text-color-hover !default;
     height: 100%;
     width: 100%;
     background-color: transparent;
+    cursor: default;
   }
 }

--- a/src/DropdownMenu/dropdownMenu.scss
+++ b/src/DropdownMenu/dropdownMenu.scss
@@ -6,6 +6,7 @@ $icon-color-hover: $text-color-hover !default;
 
 .dropdown-menu {
   position: relative;
+  z-index: 101;
   cursor: pointer;
   color: $text-color;
 
@@ -19,24 +20,19 @@ $icon-color-hover: $text-color-hover !default;
     &:hover {
       color: $icon-color-hover;
     }
-
-    &.isOpen {
-      z-index: 101;
-    }
   }
 
   .dropdown-menu-icon {
     margin: 0 10px;
   }
+}
 
-  .dropdown-menu-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    z-index: 100;
-    height: 100%;
-    width: 100%;
-    background-color: transparent;
-    cursor: default;
-  }
+.dropdown-menu-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  height: 100%;
+  width: 100%;
+  background-color: transparent;
 }


### PR DESCRIPTION
Closes #836

## Test Plan

### tests performed
* start the application
* go the the [dropdown-menu component](http://localhost:8080/#/sections/components/component/dropdown-menu?openSections=%3Bcomponents)
* Try to click outside the dropdown menu area, and see the cursor

