### PR TITLE
#862: Tablo throws when there are less then 2 children (closes #862)

### DIFF
--- a/src/tablo/plugins/columnsReorder/columnsReorderGrid.js
+++ b/src/tablo/plugins/columnsReorder/columnsReorderGrid.js
@@ -36,16 +36,16 @@ export default (Grid) =>
 
     getLocals({ className, children, columnsOrder = [], onColumnsReorder, ...gridProps }) {
 
-      const thereAreGroups = children.filter(c => c.type === ColumnGroup).length > 0;
+      const _children = [].concat(children || defaultColumns(gridProps.data));
+
+      const thereAreGroups = _children.filter(c => c.type === ColumnGroup).length > 0;
       if (thereAreGroups || !onColumnsReorder) {
         return {              // no reordering of columns if there are groups
           className,
-          children,
+          children: _children,
           ...gridProps
         };
       }
-
-      const _children = [].concat(children || defaultColumns(gridProps.data));
 
       const doOrderColumns = (child) => {
         if (child.type === Header) {
@@ -81,7 +81,7 @@ export default (Grid) =>
       const overrideHeader = ({ col, index }) => { //eslint-disable-line
         const { name, fixed } = col.props;
         const header = find([].concat(col.props.children), { type: Header }) || defaultHeader(col.props.name);
-        const otherChildren = [].concat(col.props.children).filter(ch => ch.type !== Header);
+        const otherChildren = col.props.children ? [].concat(col.props.children).filter(ch => ch.type !== Header) : [];
         const oncedOnColumnsSwitch = once(onColumnsSwitch, 200);
         const dndHeader = (
           <Header {...header.props}>


### PR DESCRIPTION
Closes #862

## Test Plan

### tests performed
- short form with no children
![image](https://cloud.githubusercontent.com/assets/925635/24911094/19090c28-1eca-11e7-9a29-2728b02acdcb.png)

- only one column
![image](https://cloud.githubusercontent.com/assets/925635/24911260/a95880a6-1eca-11e7-9151-d46b83f82b76.png)

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [x] ![Google Chrome](http://goo.gl/u4HnfV)
- [x] ![Internet Explorer](http://goo.gl/YqpZ4Z)
