### PR TITLE
#836: PanelMenu: clicking near a menu item may close the menu without calling the item's action (closes #836)

### DIFF
--- a/src/DropdownMenu/menu.scss
+++ b/src/DropdownMenu/menu.scss
@@ -19,8 +19,6 @@ $item-metadata-color: $brc-coolGrey !default;
 
   .menu-row {
     position: relative;
-    margin-top: 4px;
-    margin-bottom: 4px;
     width: 100%;
     font-size: 14px;
   }
@@ -34,7 +32,7 @@ $item-metadata-color: $brc-coolGrey !default;
 
   .menu-item {
     position: relative;
-    padding: 10px 14px;
+    padding: 14px;
     cursor: pointer;
 
     .menu-item-title {


### PR DESCRIPTION
Closes #836

## Test Plan

### tests performed
Now the `.menu-item` takes the whole `.menu-row` height making the entire area clickable.

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [x] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
