### PR TITLE
#880: Dropdown: option groups should preserve the order in which they appear (closes #880)

### DIFF
--- a/src/dropdown/Dropdown.js
+++ b/src/dropdown/Dropdown.js
@@ -168,16 +168,11 @@ export default class Dropdown extends React.Component {
   focus = () => { this.select.focus(); }
 
   optionGroupRenderer = ( title ) => {
-    if (title === 'undefined') {
-      return null;
-    }
-    else {
-      return (
-        <FlexView className='Select-option-group'>
-          {this.props.optionGroupRenderer(title)}
-        </FlexView>
-      );
-    }
+    return title ? (
+      <FlexView className='Select-option-group'>
+        {this.props.optionGroupRenderer(title)}
+      </FlexView>
+    ) : null;
   }
 
   _menuRenderer = ({
@@ -196,10 +191,14 @@ export default class Dropdown extends React.Component {
     const Option = optionComponent;
     const { groupByKey } = this.props;
     const groupedOptions = options.reduce((acc, o, i) => {
+
+      // options are already sorted by group, so we know when a new group starts
+      // just by checking the previous option
       const shouldCreateNewGroup = i === 0 || o[groupByKey] !== options[i - 1][groupByKey];
+
       if (shouldCreateNewGroup) {
         const newGroup = {
-          optionGroupTitle: o[groupByKey] || '',
+          optionGroupTitle: o[groupByKey],
           optionGroup: [o]
         };
         return [...acc, newGroup];
@@ -214,7 +213,7 @@ export default class Dropdown extends React.Component {
 
     return groupedOptions.map(({ optionGroup, optionGroupTitle }) => {
       return (
-        <FlexView column key={optionGroupTitle}>
+        <FlexView column key={optionGroupTitle || ''}>
           {this.optionGroupRenderer(optionGroupTitle)}
           {optionGroup.map((option, i) => {
             const isSelected = valueArray && valueArray.indexOf(option) > -1;

--- a/src/dropdown/Dropdown.js
+++ b/src/dropdown/Dropdown.js
@@ -5,6 +5,8 @@ import find from 'lodash/find';
 import omit from 'lodash/omit';
 import sortBy from 'lodash/orderBy';
 import findIndex from 'lodash/findIndex';
+import last from 'lodash/last';
+import dropRight from 'lodash/dropRight';
 import FlexView from 'react-flexview';
 import cx from 'classnames';
 import { warn } from '../utils/log';
@@ -202,8 +204,8 @@ export default class Dropdown extends React.Component {
         };
         return [...acc, newGroup];
       } else {
-        const lastGroup = acc.slice(-1)[0];
-        return [...acc.slice(0, -1), {
+        const lastGroup = last(acc);
+        return [...dropRight(acc), {
           optionGroupTitle: lastGroup.optionGroupTitle,
           optionGroup: [...lastGroup.optionGroup, o]
         }];

--- a/src/dropdown/Dropdown.js
+++ b/src/dropdown/Dropdown.js
@@ -194,11 +194,16 @@ export default class Dropdown extends React.Component {
     const Option = optionComponent;
     const { groupByKey } = this.props;
     const groupedOptions = options.reduce((acc, o, i) => {
-      if (i === 0 || o[groupByKey] !== options[i - 1][groupByKey]) {
-        return [...acc, { optionGroupTitle: o[groupByKey] || '', optionGroup: [o] }];
+      const shouldCreateNewGroup = i === 0 || o[groupByKey] !== options[i - 1][groupByKey];
+      if (shouldCreateNewGroup) {
+        const newGroup = {
+          optionGroupTitle: o[groupByKey] || '',
+          optionGroup: [o]
+        };
+        return [...acc, newGroup];
       } else {
         const lastGroup = acc.slice(-1)[0];
-        return [...acc.slice(0, acc.length - 1), {
+        return [...acc.slice(0, -1), {
           optionGroupTitle: lastGroup.optionGroupTitle,
           optionGroup: [...lastGroup.optionGroup, o]
         }];

--- a/src/dropdown/examples/groups.js
+++ b/src/dropdown/examples/groups.js
@@ -9,6 +9,7 @@ class Example extends React.Component {
     const { onChange, state: { value } } = this;
 
     const options = [
+      { value: 'cucumber', label: 'Cucumber', category: 'Vegetable'},
       { value: 'apple', label: 'Apple', category: 'Fruit'},
       { value: 'orange', label: 'Orange', category: 'Fruit' },
       { value: 'mandarin', label: 'Mandarin', category: 'Fruit' },
@@ -17,8 +18,8 @@ class Example extends React.Component {
       { value: 'apricot', label: 'Apricot', category: 'Fruit' },
       { value: 'tomato', label: 'Tomato', category: 'Vegetable' },
       { value: 'pineapple', label: 'Pineapple', category: 'Fruit' },
-      { value: 'cucumber', label: 'Cucumber', category: 'Vegetable'},
-      { value: 'banana', label: 'Banana', category: 'Fruit'}
+      { value: 'banana', label: 'Banana', category: 'Fruit'},
+      { value: 'meat', label: 'Meat' }
     ];
     return (
       <Dropdown


### PR DESCRIPTION
Closes #880

## Test Plan

### tests performed
- groups are preserving their order and are not sorted alphabetically
- the original order is preserved inside groups
- non-grouped options are on top (with no group header and preserving their order)
- it works fine even using arrow keys
- non-grouped dropdown works fine
![](https://i.gyazo.com/0ff8a75ed1a87749a0b657f36e3100bc.gif)

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [x] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
