### PR TITLE
#891: Dropdown: export defaultMenuRenderer (closes #891)

### DIFF
--- a/src/dropdown/index.js
+++ b/src/dropdown/index.js
@@ -1,1 +1,1 @@
-export default from './Dropdown';
+export default, { defaultMenuRenderer } from './Dropdown';


### PR DESCRIPTION
Closes #891

## Test Plan

### tests performed
- dropdown menu is still rendered as expected

![image](https://cloud.githubusercontent.com/assets/925635/26446043/d0904af6-4142-11e7-89e1-51be30913831.png)

- we can import and use `defaultMenuRenderer` from outside (tested on GDSM)

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [x] ![Google Chrome](http://goo.gl/u4HnfV)
- [x] ![Internet Explorer](http://goo.gl/YqpZ4Z)
