### PR TITLE
#996: Missing default for contextTypes in getContextWrapper util (closes #996)

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,7 +6,7 @@ export skinnable, { contains } from 'react-skinnable';
 export { props, t };
 export const stateClassUtil = (...classes) => cx([].concat(...classes).map(cl => `is-${cl}`));
 
-export const getContextWrapper = (contextTypes) => {
+export const getContextWrapper = (contextTypes = {}) => {
 
   @props({
     context: t.maybe(t.Object),


### PR DESCRIPTION
Closes #996

## Test Plan

### tests performed
- tested on alinity-pro ✅ 

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [ ] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
