### PR TITLE
#1002: Tablo: border row should be applied to inner cells  (closes #1002)

### DIFF
--- a/src/Tablo/tablo.scss
+++ b/src/Tablo/tablo.scss
@@ -9,12 +9,16 @@
   */
 
   .tablo-row {
-    border-bottom: $row-border-width solid $row-border-color;
+    .tablo-cell {
+      border-bottom: $row-border-width solid $row-border-color;
+    }
   }
 
   .fixedDataTableRowLayout_rowWrapper:last-child {
     .tablo-row {
-      border-bottom: $last-row-border-width solid $last-row-border-color;
+      .tablo-cell {
+        border-bottom: $last-row-border-width solid $last-row-border-color;
+      }
     }
   }
 


### PR DESCRIPTION
Closes #1002

## Test Plan
![image](https://user-images.githubusercontent.com/3280300/28362177-c2dc33d4-6c7b-11e7-88e2-7e12dbb11b59.png)
