### PR TITLE
#1014: Dropdown typings for `optionRenderer` and `optionGroupRenderer` are slightly broken (closes #1014)

### DIFF
--- a/src/Dropdown/Dropdown.d.ts
+++ b/src/Dropdown/Dropdown.d.ts
@@ -11,8 +11,8 @@ interface DropdownMenuRendererProps extends MenuRendererProps {
   groupByKey?: string,
   optionClassName: string,
   optionComponent: JSX.Element,
-  optionRenderer: (option: Option) => JSX.Element,
-  optionGroupRenderer: (title: string) => JSX.Element
+  optionRenderer: (option: Option, i: number) => React.ReactNode,
+  optionGroupRenderer: (title: string) => React.ReactNode
   valueKey: any
 }
 
@@ -37,13 +37,13 @@ export type DropdownProps = {
   menuPosition?: 'top' | 'bottom',
   menuRenderer?: (menuItem: DropdownMenuRendererProps) => React.ReactElement<any>, // TODO: t.ReactChildren
   groupByKey?: string,
-  optionGroupRenderer?: (title: string) => JSX.Element, // TODO: t.ReactChildren
+  optionGroupRenderer?: DropdownMenuRendererProps['optionGroupRenderer'],
   placeholder?: string | React.ReactElement<any>, // TODO: t.maybe(t.union([t.String, t.ReactElement]))
   noResultsText?: string,
   allowCreate?: boolean,
   addLabelText?: string,
   valueRenderer?: (option: Option) => JSX.Element, // TODO: t.ReactChildren
-  optionRenderer?: (option: Option) => JSX.Element, // TODO: t.ReactChildren
+  optionRenderer?: DropdownMenuRendererProps['optionRenderer'],
   delimiter?: string,
   onInputChange?: (inputValue: string) => void,
   onFocus?: FocusEventHandler<HTMLDivElement>,


### PR DESCRIPTION
Closes #1014

## Test Plan

tested in this branch https://github.omnilab.our.buildo.io/buildo/alinity-pro/tree/typo-dropdown
(see especially last commit.. still slightly broken, but usable after these fixes)

### tests performed
> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [ ] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
