### PR TITLE
#1029: ScrollView: scrollbars are visible even when thumb is hidden (closes #1029)

### DIFF
--- a/src/ScrollView/ScrollView.js
+++ b/src/ScrollView/ScrollView.js
@@ -38,6 +38,11 @@ export default class ScrollView extends React.PureComponent {
     innerComponent: 'div'
   }
 
+  state = {
+    isVerticalScrollbarVisible: false,
+    isHorizontalScrollbarVisible: false
+  }
+
   /**
    * Holds the reference to the GeminiScrollbar instance.
    * @property scrollbar <public> [Object]
@@ -52,17 +57,31 @@ export default class ScrollView extends React.PureComponent {
       element: ReactDOM.findDOMNode(this),
       createElements: false
     }).create();
+    this.saveScrollbarsState();
   }
 
   componentDidUpdate() {
     const scrollTop = this.scrollbar.getViewElement().scrollTop;
     this.scrollbar.update();
     this.scrollbar.getViewElement().scrollTop = scrollTop;
+    this.saveScrollbarsState();
   }
 
   componentWillUnmount() {
     this.scrollbar.destroy();
     this.scrollbar = null;
+  }
+
+  saveScrollbarsState() {
+    const isVerticalScrollbarVisible = !!(this.verticalThumb && this.verticalThumb.style.height && this.verticalThumb.style.height !== '0px');
+    const isHorizontalScrollbarVisible = !!(this.horizontalThumb && this.horizontalThumb.style.width && this.horizontalThumb.style.width !== '0px');
+
+    if (this.state.isVerticalScrollbarVisible !== isVerticalScrollbarVisible || this.state.isHorizontalScrollbarVisible !== isHorizontalScrollbarVisible) {
+      this.setState({ // eslint-disable-line react/no-did-update-set-state
+        isVerticalScrollbarVisible,
+        isHorizontalScrollbarVisible
+      });
+    }
   }
 
   wrapperRenderer = ({ children, ...wrapperProps }) => React.createElement(
@@ -79,9 +98,12 @@ export default class ScrollView extends React.PureComponent {
 
   getLocals() {
     const { componentProps, innerComponentProps, className, style, children } = this.props;
+    const { isVerticalScrollbarVisible, isHorizontalScrollbarVisible } = this.state;
 
     return {
       children,
+      isVerticalScrollbarVisible,
+      isHorizontalScrollbarVisible,
       Wrapper: this.wrapperRenderer,
       InnerWrapper: this.innerWrapperRenderer,
       innerWrapperProps: innerComponentProps,
@@ -93,15 +115,15 @@ export default class ScrollView extends React.PureComponent {
     };
   }
 
-  template({ children, Wrapper, wrapperProps, InnerWrapper, innerWrapperProps }) {
+  template({ children, Wrapper, wrapperProps, InnerWrapper, innerWrapperProps, isVerticalScrollbarVisible, isHorizontalScrollbarVisible }) {
     return (
       <ResizeSensor onResize={() => this.forceUpdate()}>
         <Wrapper {...wrapperProps}>
-          <div className='gm-scrollbar -vertical'>
-            <div className='thumb' />
+          <div className={cx('gm-scrollbar -vertical', { visible: isVerticalScrollbarVisible })}>
+            <div className='thumb' ref={ref => { this.verticalThumb = ref; }} />
           </div>
-          <div className='gm-scrollbar -horizontal'>
-            <div className='thumb' />
+          <div className={cx('gm-scrollbar -horizontal', { visible: isHorizontalScrollbarVisible })}>
+            <div className='thumb' ref={ref => { this.horizontalThumb = ref; }} />
           </div>
           <div className='gm-scroll-view'>
             <ResizeSensor onResize={() => this.forceUpdate()}>

--- a/src/ScrollView/scrollView.scss
+++ b/src/ScrollView/scrollView.scss
@@ -33,25 +33,26 @@ body > div::-webkit-scrollbar {
       width: auto;
       transition-property: background-color width;
 
-      .thumb {
-        position: static;
-        width: 0;
-        transition: width 250ms ease;
+      &:not(.visible) {
+        visibility: hidden;
+        pointer-events: none;
       }
 
-      .thumb[style*='height'] {
+      .thumb {
+        position: static;
         margin: 0;
         width: $scrollbar-size;
+        transition: width 250ms ease;
       }
 
       &:hover,
       &:active {
-        .thumb[style*='height'] {
+        .thumb {
           width: $scrollbar-size-hover;
         }
       }
 
-      &:active .thumb[style*='height'] {
+      &:active .thumb {
         background-color: $scrollbar-color;
         transition: background-color 250ms ease;
       }
@@ -63,13 +64,14 @@ body > div::-webkit-scrollbar {
       height: auto;
       transition-property: background-color height;
 
-      .thumb {
-        position: static;
-        height: 0;
-        transition: height 250ms ease;
+      &:not(.visible) {
+        visibility: hidden;
+        pointer-events: none;
       }
 
-      .thumb[style*='width'] {
+      .thumb {
+        position: static;
+        transition: height 250ms ease;
         margin: 0;
         height: $scrollbar-size;
       }
@@ -78,12 +80,12 @@ body > div::-webkit-scrollbar {
       &:active {
         background: rgba($scrollbar-container-color, .8);
 
-        .thumb[style*='width'] {
+        .thumb {
           height: $scrollbar-size-hover;
         }
       }
 
-      &:active .thumb[style*='width'] {
+      &:active .thumb {
         background-color: $scrollbar-color;
         transition: background-color 250ms ease;
       }


### PR DESCRIPTION
Closes #1029

## Test Plan

### tests performed
tested on AlinityPRO:
- scrollbars work as before
- they're no longer visible/hoverable when thumb has height/width `0`
- if `children` use `PureComponent` (as we're doing) no useless render
  - tested on `UserPreferences` page: same number of renders for `UserRow`

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [ ] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
