### PR TITLE
#1139: [Typo] TextOverflow popover.event type (closes #1139)

### DIFF
--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -3,7 +3,7 @@ import * as cx from 'classnames';
 import { t, ReactChildren, stateClassUtil, props } from '../utils';
 import FormattedText from '../FormattedText/FormattedText';
 import Popover, { PopoverProps } from '../Popover/Popover';
-import { ObjectOverwrite } from 'typelevel-ts';
+import { ObjectOmit } from 'typelevel-ts';
 
 export namespace TooltipProps {
   export type Type = 'light' | 'dark';
@@ -14,10 +14,10 @@ export type TooltipRequiredProps = {
   /** the element over which the tooltip is shown */
   children: React.ReactNode
   /** popover props */
-  popover: ObjectOverwrite<PopoverProps.Popover, {
+  popover: ObjectOmit<PopoverProps.Popover, 'content' | 'event'> & {
     content: string,
     event?: undefined
-  }>,
+  },
   /** add class name */
   className?: string,
   /** add id */


### PR DESCRIPTION
Closes #1139

## Test Plan

### tests performed
tested inside VSCode:
```tsx
// OK
const x: TooltipRequiredProps = {
  children: '' as React.ReactNode,
  popover: {
    content: ''
  }
};

// ERROR for `event`
const x: TooltipRequiredProps = {
  children: '' as React.ReactNode,
  popover: {
    content: '',
    event: 'hover'
  }
};
```

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [ ] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
