### PR TITLE
#1133: Dropdown: clearing returns `null` to `onChange` when `multi = true` (closes #1133)

### DIFF
--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -289,7 +289,7 @@ export default class Dropdown extends React.Component<Props> {
   }
 
   _onChange = (_value?: Value | null) => {
-    const value = isEmptyArray(_value) ? null : _value;
+    const value = (_value === '' || isEmptyArray(_value)) ? null : _value;
     return this.props.onChange(value);
   }
 


### PR DESCRIPTION
Closes #1133

## Test Plan

### tests performed
tested with examples:
![image](https://user-images.githubusercontent.com/4029499/31814760-e712e420-b58a-11e7-99e0-7762ec332afb.png)

returns `null` when you manually remove the last value
#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [ ] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
