### PR TITLE
Allow custom prefixes for icons (in Icon and Button) (closes #1150)

### DIFF
--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -17,7 +17,9 @@ export type ButtonRequiredProps = {
   /** type of the button (default, primary, positive, negative, flat) */
   type?: Button.ButtonType
   /** shortcut for type "flat" */
-  flat?: boolean,
+  flat?: boolean
+  /** custom prefix for the Icon, if any */
+  iconPrefix?: string
 }
 
 export type ButtonDefaultProps = {
@@ -79,6 +81,7 @@ export const ButtonPropTypes = {
   onClick: t.Function,
   label: t.maybe(t.union([t.String, t.Object])),
   icon: t.maybe(t.union([t.String, t.Object])),
+  iconPrefix: t.maybe(t.String),
   children: t.maybe(t.String),
   type: t.maybe(ButtonType),
   primary: t.maybe(t.Boolean),
@@ -127,9 +130,9 @@ export class Button extends React.PureComponent<Button.Props> {
     </FlexView>
   );
 
-  templateIcon = (icon: string) => (
+  templateIcon = (icon: string, iconPrefix?: string) => (
     <FlexView className='button-icon' shrink={false}>
-      <Icon icon={icon} />
+      <Icon icon={icon} prefix={iconPrefix} />
     </FlexView>
   );
 
@@ -149,6 +152,7 @@ export class Button extends React.PureComponent<Button.Props> {
       flat,
       fluid,
       icon: _icon,
+      iconPrefix,
       label: _label, children,
       onClick,
       primary,
@@ -199,7 +203,7 @@ export class Button extends React.PureComponent<Button.Props> {
           style={style}
         >
           {loading && this.templateLoading()}
-          {icon && this.templateIcon(icon)}
+          {icon && this.templateIcon(icon, iconPrefix)}
           {label && this.templateLabel(label, textOverflow)}
         </FlexView>
       </div>

--- a/src/Icon/Icon.tsx
+++ b/src/Icon/Icon.tsx
@@ -7,6 +7,7 @@ const PositiveInteger = t.refinement(t.Number, x => x % 1 === 0 && x > 0, 'Posit
 
 export const Props = {
   icon: t.maybe(t.String),
+  prefix: t.maybe(t.String),
   color: t.maybe(t.String),
   className: t.maybe(t.String),
   style: t.maybe(t.Object),
@@ -20,7 +21,9 @@ export type IconDefaultProps = {
   /** onClick callback*/
   onClick: React.MouseEventHandler<HTMLElement>,
   /** an optional style object to pass to top level element of the component */
-  style: React.CSSProperties
+  style: React.CSSProperties,
+  /** prefix for the icons. Defaults to 'icon' */
+  prefix: string
 };
 
 export type IconRequiredProps = {
@@ -44,12 +47,13 @@ export class Icon extends React.PureComponent<Icon.Props> {
   static defaultProps: IconDefaultProps = {
     paths: 1,
     onClick: () => {},
-    style: {}
+    style: {},
+    prefix: 'icon'
   };
 
   render() {
-    const { paths, onClick, className: _className, icon, color, style: _style } = this.props as IconDefaultedProps;
-    const className = cx('icon', `icon-${icon}`, _className);
+    const { paths, onClick, className: _className, icon, color, style: _style, prefix } = this.props as IconDefaultedProps;
+    const className = cx(prefix, `${prefix}-${icon}`, _className);
     const style =  { ..._style, color: color || _style.color };
 
     return icon ? (

--- a/test/components/Icon.test.tsx
+++ b/test/components/Icon.test.tsx
@@ -66,6 +66,14 @@ describe('Icon', () => {
     expect(component.hasClass('myicon')).toBe(true);
   });
 
+  it('computes className with custom prefix', () => {
+    const component = shallow(
+      <Icon icon='foo' prefix='fa' />
+    );
+    expect(component.hasClass('fa')).toBe(true);
+    expect(component.hasClass('fa-foo')).toBe(true);
+  });
+
   it('computes color when not provided', () => {
     const component = shallow(
       <Icon icon='foo' />


### PR DESCRIPTION
Added a simple test for the new `Icon.prefix` prop

Would be nice to have `Button.iconPrefix` usable only in case of `Button.icon`.. This was the quickest solution for the moment