### PR TITLE
#1164: Popover does not work on React16 when attached to body (closes #1164)

### DIFF
--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -113,7 +113,7 @@ export class Popover extends React.Component<Popover.Props, State> {
   private containerNode: Element | null;
   private onMouseEventDebouncedWhenOpen: ((_: string) => void) & _.Cancelable | null;
   private onMouseEventDebouncedWhenClosed: ((_: string) => void) & _.Cancelable | null;
-  private ContextWrapper: React.ComponentType<{ context?: { [_: string]: any }, children: any }>;
+  private ContextWrapper: React.ComponentType<{ onMount?: () => void, context?: { [_: string]: any }, children: any }>;
 
   // LIFECYCLE
 
@@ -314,10 +314,18 @@ export class Popover extends React.Component<Popover.Props, State> {
     const hiddenPopover = this.getHiddenPopover();
     const { context } = this.getPopoverProps();
     const { ContextWrapper } = this;
-    ReactDOM.render(<ContextWrapper context={context}>{hiddenPopover}</ContextWrapper>, this.containerNode);
 
-    // save popover size (visible popover will be rendered in componentDidUpdate)
-    setTimeout(this.saveValuesFromNodeTree);
+    // render Popover and save popover size in "onMount" cb (visible popover will be rendered in componentDidUpdate)
+    ReactDOM.render(
+      <ContextWrapper
+        onMount={this.saveValuesFromNodeTree}
+        context={context}
+      >
+        {hiddenPopover}
+      </ContextWrapper>,
+
+      this.containerNode
+    );
   };
 
   removePopover = () => {

--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -113,7 +113,7 @@ export class Popover extends React.Component<Popover.Props, State> {
   private containerNode: Element | null;
   private onMouseEventDebouncedWhenOpen: ((_: string) => void) & _.Cancelable | null;
   private onMouseEventDebouncedWhenClosed: ((_: string) => void) & _.Cancelable | null;
-  private ContextWrapper: React.ComponentType<{ onMount?: () => void, context?: { [_: string]: any }, children: any }>;
+  private ContextWrapper: React.ComponentType<{ context?: { [_: string]: any }, children: any }>;
 
   // LIFECYCLE
 
@@ -317,14 +317,9 @@ export class Popover extends React.Component<Popover.Props, State> {
 
     // render Popover and save popover size in "onMount" cb (visible popover will be rendered in componentDidUpdate)
     ReactDOM.render(
-      <ContextWrapper
-        onMount={this.saveValuesFromNodeTree}
-        context={context}
-      >
-        {hiddenPopover}
-      </ContextWrapper>,
-
-      this.containerNode
+      <ContextWrapper context={context}>{hiddenPopover}</ContextWrapper>,
+      this.containerNode,
+      this.saveValuesFromNodeTree
     );
   };
 

--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -111,7 +111,6 @@ export class Popover extends React.Component<Popover.Props, State> {
 
   private initialized: boolean;
   private containerNode: Element | null;
-  private popoverNode: Element | null;
   private onMouseEventDebouncedWhenOpen: ((_: string) => void) & _.Cancelable | null;
   private onMouseEventDebouncedWhenClosed: ((_: string) => void) & _.Cancelable | null;
   private ContextWrapper: React.ComponentType<{ context?: { [_: string]: any }, children: any }>;
@@ -232,10 +231,10 @@ export class Popover extends React.Component<Popover.Props, State> {
     };
   };
 
-  getPopoverNode = (): Element => {
-    let popover: Element;
+  getPopoverNode = (): Element | null => {
+    let popover: Element | null;
     if (this.isAbsolute()) {
-      popover = this.popoverNode!;
+      popover = this.containerNode ? this.containerNode.children[0] : null;
     } else {
       const childrenNode = ReactDOM.findDOMNode(this.refs.children);
       popover = childrenNode.children[1];
@@ -316,9 +315,6 @@ export class Popover extends React.Component<Popover.Props, State> {
     const { context } = this.getPopoverProps();
     const { ContextWrapper } = this;
     ReactDOM.render(<ContextWrapper context={context}>{hiddenPopover}</ContextWrapper>, this.containerNode);
-
-    // add pointer to popover node
-    this.popoverNode = this.containerNode.children[0];
 
     // save popover size (visible popover will be rendered in componentDidUpdate)
     this.saveValuesFromNodeTree();

--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -317,7 +317,7 @@ export class Popover extends React.Component<Popover.Props, State> {
     ReactDOM.render(<ContextWrapper context={context}>{hiddenPopover}</ContextWrapper>, this.containerNode);
 
     // save popover size (visible popover will be rendered in componentDidUpdate)
-    this.saveValuesFromNodeTree();
+    setTimeout(this.saveValuesFromNodeTree);
   };
 
   removePopover = () => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,20 +11,26 @@ export const stateClassUtil = (classes: string[]): string => cx(classes.map(cl =
 
 type Props = {
   context?: { [k: string]: any },
-  children: any
+  children: any,
+  onMount?: () => void
 };
 
 export const getContextWrapper = (contextTypes = {}): React.ComponentType<Props> => {
 
   @props({
     context: t.maybe(t.Object),
-    children: ReactChildren
+    children: ReactChildren,
+    onMount: t.maybe(t.Function)
   })
   class ContextWrapper extends React.Component<Props> {
 
     static childContextTypes = contextTypes;
 
     getChildContext = () => this.props.context || {};
+
+    componentDidMount() {
+      this.props.onMount && this.props.onMount();
+    }
 
     render() {
       return this.props.children;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,26 +11,20 @@ export const stateClassUtil = (classes: string[]): string => cx(classes.map(cl =
 
 type Props = {
   context?: { [k: string]: any },
-  children: any,
-  onMount?: () => void
+  children: any
 };
 
 export const getContextWrapper = (contextTypes = {}): React.ComponentType<Props> => {
 
   @props({
     context: t.maybe(t.Object),
-    children: ReactChildren,
-    onMount: t.maybe(t.Function)
+    children: ReactChildren
   })
   class ContextWrapper extends React.Component<Props> {
 
     static childContextTypes = contextTypes;
 
     getChildContext = () => this.props.context || {};
-
-    componentDidMount() {
-      this.props.onMount && this.props.onMount();
-    }
 
     render() {
       return this.props.children;


### PR DESCRIPTION
Closes #1164

## Test Plan

### tests performed
example with `attachToBody` works both on React16 and React15

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [ ] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
