### PR TITLE
#1179: FormattedText: there is no way to disable linkify feature (closes #1179)

### DIFF
--- a/src/FormattedText/Examples.md
+++ b/src/FormattedText/Examples.md
@@ -4,7 +4,7 @@
 ```js
 const content = 'First line.\n\nI left an empty line.\n\n\n\nI left three empty lines.\nThis line comes after a single "\\n"\n\nhttps://google.com';
 
-<FormattedText>
+<FormattedText linkify>
   {content}
 </FormattedText>
 ```

--- a/src/FormattedText/FormattedText.tsx
+++ b/src/FormattedText/FormattedText.tsx
@@ -10,6 +10,8 @@ export namespace FormattedText {
   export type Props = {
     /** The content of the paragraph */
     children: string,
+    /** Pass `true` to linkify links */
+    linkify?: boolean,
     id?: string,
     className?: string,
     style?: React.CSSProperties
@@ -18,6 +20,7 @@ export namespace FormattedText {
 
 export const Props = {
   children: t.String,
+  linkify: t.Boolean,
   id: t.maybe(t.String),
   className: t.maybe(t.String),
   style: t.maybe(t.Object)
@@ -67,11 +70,14 @@ export class FormattedText extends React.PureComponent<FormattedText.Props> {
   }
 
   render() {
-    const { children, ...props } = this.props;
+    const { children, linkify, ...props } = this.props;
+
+    const formattedText = this.replaceBreaklinesWithBR(children);
     const newProps = {
       ...props,
-      children: this.replaceLinksWithA(this.replaceBreaklinesWithBR(children))
+      children: linkify ? this.replaceLinksWithA(formattedText) : formattedText
     }
+
     return (
       <span {...newProps} />
     );


### PR DESCRIPTION
Closes #1179

## Test Plan

### tests performed
[![https://gyazo.com/ac490dcefb15c1c8c512c445103ecce3](https://i.gyazo.com/ac490dcefb15c1c8c512c445103ecce3.gif)](https://gyazo.com/ac490dcefb15c1c8c512c445103ecce3)

#### cross browser compatibility
> Should be compatible with every browser below. Check the ones you tested!

- [ ] ![Google Chrome](http://goo.gl/u4HnfV)
- [ ] ![Internet Explorer](http://goo.gl/YqpZ4Z)

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
