### PR TITLE
#1266: DatePicker doesn't allow to select past days (closes #1266)

### DIFF
--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -163,7 +163,7 @@ export class DatePicker<T extends DatePicker.Value = never> extends React.PureCo
     const maxDate = valueToMomentDate(this.props.maxDate);
 
     return (!!minDate && day < minDate) || (!!maxDate && day > maxDate);
-  }  
+  }
 
   initialVisibleMonth = () => valueToMomentDate(this.props.startDate)
 
@@ -257,7 +257,7 @@ export class DatePicker<T extends DatePicker.Value = never> extends React.PureCo
 
     return (
       <FlexView {...wrapperProps}>
-        <SingleDatePicker {...datePickerProps}/>
+        <SingleDatePicker {...datePickerProps} />
       </FlexView>
     );
   }


### PR DESCRIPTION
Closes #1266

## Test Plan

### tests performed

run react-components on local machine, tested the live examples of datepicker and check that now it's possible to select any date starting from the given minDate

![screen shot 2018-08-23 at 10 24 48](https://user-images.githubusercontent.com/4497461/44513869-e1f92a00-a6be-11e8-8f8f-ab16256a1726.png)
