### PR TITLE
#1294: Can't pass a React Element as label for InputField (closes #1294)

### DIFF
--- a/src/FormField/InputField.tsx
+++ b/src/FormField/InputField.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
-import { props, t, ReactChild } from "../utils";
+import { props, t, ReactChild, ObjectOmit } from "../utils";
 import * as cx from "classnames";
 import View from "react-flexview";
 import Input from "../Input";
 import { FormField } from "./FormField";
 
 export namespace InputField {
-  export type Props = {
+  type FieldProps = {
     /** the label for the field */
     label: JSX.Element | string;
     /** whether the field is required */
@@ -21,7 +21,9 @@ export namespace InputField {
     style?: React.CSSProperties;
     /** an optional id passed to the input component */
     id?: string;
-  } & Input.Props;
+  };
+
+  export type Props = FieldProps & ObjectOmit<Input.Props, keyof FieldProps>;
 }
 
 export const Props = {

--- a/src/FormField/PasswordInputField.tsx
+++ b/src/FormField/PasswordInputField.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
-import { props, t, ReactChild } from "../utils";
+import { props, t, ReactChild, ObjectOmit } from "../utils";
 import * as cx from "classnames";
 import View from "react-flexview";
 import { PasswordInput } from "../Input";
 import { FormField } from "./FormField";
 
 export namespace PasswordInputField {
-  export type Props = {
+  type FieldProps = {
     /** the label for the field */
     label: JSX.Element | string;
     /** whether the field is required */
@@ -21,7 +21,9 @@ export namespace PasswordInputField {
     style?: React.CSSProperties;
     /** an optional id passed to the input component */
     id?: string;
-  } & PasswordInput.Props;
+  };
+  export type Props = FieldProps &
+    ObjectOmit<PasswordInput.Props, keyof FieldProps>;
 }
 
 export const Props = {

--- a/src/FormField/TextareaField.tsx
+++ b/src/FormField/TextareaField.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
-import { props, t, ReactChild } from "../utils";
+import { props, t, ReactChild, ObjectOmit } from "../utils";
 import * as cx from "classnames";
 import View from "react-flexview";
 import Textarea from "../Textarea";
 import { FormField } from "./FormField";
 
 export namespace TextareaField {
-  export type Props = {
+  type FieldProps = {
     /** the label for the field */
     label: JSX.Element | string;
     /** whether the field is required */
@@ -21,7 +21,9 @@ export namespace TextareaField {
     style?: React.CSSProperties;
     /** an optional id passed to the input component */
     id?: string;
-  } & Textarea.Props;
+  };
+
+  export type Props = FieldProps & ObjectOmit<Textarea.Props, keyof FieldProps>;
 }
 
 export const Props = {


### PR DESCRIPTION
Closes #1294

## Test Plan

### tests performed
- VSCode now shows the `label` prop as `JSX.Element | string`
- `<InputField label={<View />} />` => no errors for the `label` prop