### PR TITLE
#1329: bring back Timepicker in showroom (closes #1329)

### DIFF
--- a/src/TimePicker/TimePicker.tsx
+++ b/src/TimePicker/TimePicker.tsx
@@ -49,13 +49,13 @@ const getComponents = (
 ): SelectNS.Props<TimeDropdownOption>["components"] => {
   return timeFormatter
     ? {
-      Option: props => (
-        <components.Option {...props}>
-          {timeFormatter(props.data.time)}
-        </components.Option>
-      ),
-      SingleValue: props => timeFormatter(props.data.time)
-    }
+        Option: props => (
+          <components.Option {...props}>
+            {timeFormatter(props.data.time)}
+          </components.Option>
+        ),
+        SingleValue: props => timeFormatter(props.data.time)
+      }
     : {};
 };
 
@@ -173,9 +173,9 @@ const createTimeList = (
   } else {
     return timeFormat !== H24
       ? [
-        { hours, minutes, timeFormat },
-        { hours: normalizeHoursToH24(hours), minutes, timeFormat }
-      ]
+          { hours, minutes, timeFormat },
+          { hours: normalizeHoursToH24(hours), minutes, timeFormat }
+        ]
       : [{ hours, minutes, timeFormat }];
   }
 };
@@ -218,8 +218,8 @@ const makeOptions = (
   const timeList = ((time === inputError
     ? []
     : createTimeList(time as TimePicker.Time, timeFormat)) as (
-      | TimePicker.Time
-      | TimePicker.TimeAndFormat)[]) // TODO(typo)
+    | TimePicker.Time
+    | TimePicker.TimeAndFormat)[]) // TODO(typo)
     .concat(compact([selectedValue]));
   const filteredTimeList = timeList.filter(
     filterTime({
@@ -283,8 +283,8 @@ type TimeDropdownOption = {
 
 @props(Props)
 export class TimePicker extends React.Component<
-TimePicker.Props,
-{ inputValue: string }
+  TimePicker.Props,
+  { inputValue: string }
 > {
   static defaultProps = {
     placeholder: `--${separator}--`,
@@ -359,5 +359,5 @@ export {
   makeOptions,
   TimeFormat,
   Time,
-  Props,
+  Props
 };

--- a/src/TimePicker/TimePicker.tsx
+++ b/src/TimePicker/TimePicker.tsx
@@ -49,13 +49,13 @@ const getComponents = (
 ): SelectNS.Props<TimeDropdownOption>["components"] => {
   return timeFormatter
     ? {
-        Option: props => (
-          <components.Option {...props}>
-            {timeFormatter(props.data.time)}
-          </components.Option>
-        ),
-        SingleValue: props => timeFormatter(props.data.time)
-      }
+      Option: props => (
+        <components.Option {...props}>
+          {timeFormatter(props.data.time)}
+        </components.Option>
+      ),
+      SingleValue: props => timeFormatter(props.data.time)
+    }
     : {};
 };
 
@@ -173,9 +173,9 @@ const createTimeList = (
   } else {
     return timeFormat !== H24
       ? [
-          { hours, minutes, timeFormat },
-          { hours: normalizeHoursToH24(hours), minutes, timeFormat }
-        ]
+        { hours, minutes, timeFormat },
+        { hours: normalizeHoursToH24(hours), minutes, timeFormat }
+      ]
       : [{ hours, minutes, timeFormat }];
   }
 };
@@ -218,8 +218,8 @@ const makeOptions = (
   const timeList = ((time === inputError
     ? []
     : createTimeList(time as TimePicker.Time, timeFormat)) as (
-    | TimePicker.Time
-    | TimePicker.TimeAndFormat)[]) // TODO(typo)
+      | TimePicker.Time
+      | TimePicker.TimeAndFormat)[]) // TODO(typo)
     .concat(compact([selectedValue]));
   const filteredTimeList = timeList.filter(
     filterTime({
@@ -283,8 +283,8 @@ type TimeDropdownOption = {
 
 @props(Props)
 export class TimePicker extends React.Component<
-  TimePicker.Props,
-  { inputValue: string }
+TimePicker.Props,
+{ inputValue: string }
 > {
   static defaultProps = {
     placeholder: `--${separator}--`,

--- a/src/TimePicker/TimePicker.tsx
+++ b/src/TimePicker/TimePicker.tsx
@@ -352,12 +352,12 @@ TimePicker.Props,
 
 // must be exported after TimePicker class in order to be compatible with react-styleguide (see #1153)
 export {
-  TimeFormat,
-  Time,
-  Props,
   toOption,
   parseInTimeFormat,
   createTimeList,
   filterTime,
-  makeOptions
+  makeOptions,
+  TimeFormat,
+  Time,
+  Props,
 };


### PR DESCRIPTION
Closes #1329

## Test Plan

### tests performed
when running styleguidist, `Timepicker` name displays correctly:
<img width="471" alt="screenshot 2019-03-06 at 16 45 00" src="https://user-images.githubusercontent.com/10383300/53893859-4f532380-402f-11e9-9bf6-560f533e17f0.png">
