### PR TITLE
#1347: Remove returnFormat prop from DatePicker (closes #1347)

### DIFF
--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -6,42 +6,27 @@ import { props, t, ReactChild } from "../utils";
 import * as moment from "moment";
 
 export namespace DatePicker {
-  export type Value = string | Date | moment.Moment;
-  export type OnChangeProps<T extends Value> =
-    | {
-        /** MomentJS format used to format date before returing through "onChange" */
-        returnFormat?: never;
-        /** called when value changes */
-        onChange?: (date?: T) => void;
-      }
-    | {
-        /** MomentJS format used to format date before returing through "onChange" */
-        returnFormat: string;
-        /** called when value changes */
-        onChange?: (date?: string) => void;
-      };
-
-  export type Props<T extends Value> = {
+  export type Props = {
     /** an optional id to pass to top level element of the component */
     id?: string;
     /** current date */
-    value?: T;
+    value?: Date;
     /** default date */
-    defaultValue?: T;
+    defaultValue?: Date;
+    /** called when value changes */
+    onChange?: (date?: Date) => void;
     /** called when datepicker is closed */
     onHide?: () => void;
     /** MomentJS format used to display current date */
     displayFormat?: string;
-    /** called when value is cleared */
-    onClear?: () => void;
     /** minimum date selectable by the user */
-    minDate?: Value;
+    minDate?: Date | string;
     /** maximum date selectable by the user */
-    maxDate?: Value;
+    maxDate?: Date | string;
     /** if set, the datepicker will highlight days in the range starting from this date and ending to the hovered or selected date */
-    fromDate?: Value;
+    fromDate?: Date | string;
     /** if set, the datepicker will highlight days in the range starting from the hovered or selected date to this value */
-    toDate?: Value;
+    toDate?: Date | string;
     /** set to true to display two month */
     displayTwoMonths?: boolean;
     /** whether the input box should be small or not */
@@ -49,7 +34,7 @@ export namespace DatePicker {
     /** the icon to show in the input field */
     icon?: JSX.Element;
     /** specify an initial "visible" date with no need to select a defaultValue */
-    startDate?: Value;
+    startDate?: Date | string;
     /** locale used for translations */
     locale?: string;
     /** whether the datepicker should be disabled or not */
@@ -60,11 +45,11 @@ export namespace DatePicker {
     className?: string;
     /** an optional style object to pass to top level element of the component */
     style?: React.CSSProperties;
-  } & OnChangeProps<T>;
+  };
 }
 
 export type State = {
-  value?: DatePicker.Value;
+  value?: moment.Moment;
   hoveredDay?: moment.Moment;
   focused: boolean;
 };
@@ -86,11 +71,8 @@ export type State = {
  *
  */
 
-const MomentDate = t.irreducible("MomentDate", x => moment.isMoment(x));
-const ValueType = t.union([t.String, t.Date, MomentDate]);
-
 const valueToMomentDate: (
-  value?: DatePicker.Value
+  value?: Date | string
 ) => moment.Moment | undefined = value => (!value ? undefined : moment(value));
 
 const angleLeftIcon = (
@@ -130,21 +112,19 @@ const calendarIcon = (
 
 export const Props = {
   id: t.maybe(t.String),
-  value: t.maybe(ValueType),
-  defaultValue: t.maybe(ValueType),
+  value: t.maybe(t.Date),
+  defaultValue: t.maybe(t.Date),
   onChange: t.maybe(t.Function),
   onHide: t.maybe(t.Function),
-  returnFormat: t.maybe(t.String),
   displayFormat: t.maybe(t.String),
-  onClear: t.maybe(t.Function),
-  minDate: t.maybe(ValueType),
-  maxDate: t.maybe(ValueType),
-  fromDate: t.maybe(ValueType),
-  toDate: t.maybe(ValueType),
+  minDate: t.maybe(t.union([t.Date, t.String])),
+  maxDate: t.maybe(t.union([t.Date, t.String])),
+  fromDate: t.maybe(t.union([t.Date, t.String])),
+  toDate: t.maybe(t.union([t.Date, t.String])),
   displayTwoMonths: t.maybe(t.Boolean),
   small: t.maybe(t.Boolean),
   icon: t.maybe(ReactChild),
-  startDate: t.maybe(ValueType),
+  startDate: t.maybe(t.union([t.Date, t.String])),
   locale: t.maybe(t.String),
   onFocusChange: t.maybe(t.Function),
   disabled: t.maybe(t.Boolean),
@@ -156,16 +136,14 @@ export const Props = {
  * A decent and pretty date picker to be used with React
  */
 @props(Props)
-export class DatePicker<
-  T extends DatePicker.Value = never
-> extends React.PureComponent<DatePicker.Props<T>, State> {
+export class DatePicker extends React.PureComponent<DatePicker.Props, State> {
   componentWillMount() {
     if (this.props.locale) {
       moment.locale(this.props.locale);
     }
   }
 
-  componentWillReceiveProps(newProps: DatePicker.Props<T>) {
+  componentWillReceiveProps(newProps: DatePicker.Props) {
     if (newProps.locale !== this.props.locale) {
       moment.locale(newProps.locale);
     }
@@ -178,19 +156,18 @@ export class DatePicker<
   };
 
   _onChange = (value: moment.Moment | null) => {
-    const { returnFormat, defaultValue, onClear, onChange } = this.props;
+    const { defaultValue, onChange } = this.props;
     if (!value) {
       this.setState(
         {
           value: valueToMomentDate(defaultValue)
         },
-        onClear
+        () => onChange && onChange(undefined)
       );
     } else {
-      const _value = returnFormat ? value.format(returnFormat) : value;
       this.setState(
         { value },
-        () => onChange && (onChange as any)(_value || undefined)
+        () => onChange && onChange(value.toDate() || undefined)
       );
     }
   };

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -20,13 +20,13 @@ export namespace DatePicker {
     /** MomentJS format used to display current date */
     displayFormat?: string;
     /** minimum date selectable by the user */
-    minDate?: Date | string;
+    minDate?: Date;
     /** maximum date selectable by the user */
-    maxDate?: Date | string;
+    maxDate?: Date;
     /** if set, the datepicker will highlight days in the range starting from this date and ending to the hovered or selected date */
-    fromDate?: Date | string;
+    fromDate?: Date;
     /** if set, the datepicker will highlight days in the range starting from the hovered or selected date to this value */
-    toDate?: Date | string;
+    toDate?: Date;
     /** set to true to display two month */
     displayTwoMonths?: boolean;
     /** whether the input box should be small or not */
@@ -34,7 +34,7 @@ export namespace DatePicker {
     /** the icon to show in the input field */
     icon?: JSX.Element;
     /** specify an initial "visible" date with no need to select a defaultValue */
-    startDate?: Date | string;
+    startDate?: Date;
     /** locale used for translations */
     locale?: string;
     /** whether the datepicker should be disabled or not */
@@ -71,9 +71,8 @@ export type State = {
  *
  */
 
-const valueToMomentDate: (
-  value?: Date | string
-) => moment.Moment | undefined = value => (!value ? undefined : moment(value));
+const valueToMomentDate: (value?: Date) => moment.Moment | undefined = value =>
+  !value ? undefined : moment(value);
 
 const angleLeftIcon = (
   <svg width="10" height="10" viewBox="0 0 32 32">
@@ -117,14 +116,14 @@ export const Props = {
   onChange: t.maybe(t.Function),
   onHide: t.maybe(t.Function),
   displayFormat: t.maybe(t.String),
-  minDate: t.maybe(t.union([t.Date, t.String])),
-  maxDate: t.maybe(t.union([t.Date, t.String])),
-  fromDate: t.maybe(t.union([t.Date, t.String])),
-  toDate: t.maybe(t.union([t.Date, t.String])),
+  minDate: t.maybe(t.Date),
+  maxDate: t.maybe(t.Date),
+  fromDate: t.maybe(t.Date),
+  toDate: t.maybe(t.Date),
   displayTwoMonths: t.maybe(t.Boolean),
   small: t.maybe(t.Boolean),
   icon: t.maybe(ReactChild),
-  startDate: t.maybe(t.union([t.Date, t.String])),
+  startDate: t.maybe(t.Date),
   locale: t.maybe(t.String),
   onFocusChange: t.maybe(t.Function),
   disabled: t.maybe(t.Boolean),

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -165,10 +165,7 @@ export class DatePicker extends React.PureComponent<DatePicker.Props, State> {
         () => onChange && onChange(undefined)
       );
     } else {
-      this.setState(
-        { value },
-        () => onChange && onChange(value.toDate() || undefined)
-      );
+      this.setState({ value }, () => onChange && onChange(value.toDate()));
     }
   };
 

--- a/src/DatePicker/Examples.md
+++ b/src/DatePicker/Examples.md
@@ -15,7 +15,7 @@ function onChange(value) {
     onChange={onChange}
     displayFormat='MMMM Do YYYY'
     locale='en'
-    minDate={new Date('2017-07-04')}
+    minDate={'2017-07-04'}
   />
 </FlexView>
 ```

--- a/src/DatePicker/Examples.md
+++ b/src/DatePicker/Examples.md
@@ -15,7 +15,7 @@ function onChange(value) {
     onChange={onChange}
     displayFormat='MMMM Do YYYY'
     locale='en'
-    minDate={'2017-07-04'}
+    minDate={new Date()}
   />
 </FlexView>
 ```

--- a/src/DatePicker/Examples.md
+++ b/src/DatePicker/Examples.md
@@ -14,8 +14,8 @@ function onChange(value) {
     value={state.value}
     onChange={onChange}
     displayFormat='MMMM Do YYYY'
-    locale='fr'
-    minDate='2017-07-04'
+    locale='en'
+    minDate={new Date('2017-07-04')}
   />
 </FlexView>
 ```

--- a/src/FormField/DatePickerField.tsx
+++ b/src/FormField/DatePickerField.tsx
@@ -17,8 +17,6 @@ type NonDefaultProps = {
   viewProps?: FormField.Props["viewProps"];
   /** an optional hint describing what's the expected value for the field (e.g. sample value or short description) */
   hint?: FormField.Props["hint"];
-  /** An optional custom renderer for DatePicker */
-  datePickerRenderer?: (props: DatePicker.Props) => JSX.Element;
   /** an optional class name to pass to top level element of the component */
   className?: string;
   /** an optional style object to pass to top level element of the component */

--- a/src/FormField/DatePickerField.tsx
+++ b/src/FormField/DatePickerField.tsx
@@ -1,15 +1,14 @@
 import * as React from "react";
-import { ObjectOmit } from "../utils";
 import * as cx from "classnames";
 import DatePicker from "../DatePicker";
 import { FormField } from "./FormField";
 
-type DefaultProps<T extends DatePicker.Value> = {
+type DefaultProps = {
   /** An optional custom renderer for DatePicker */
-  datePickerRenderer: (props: DatePicker.Props<T>) => JSX.Element;
+  datePickerRenderer: (props: DatePicker.Props) => JSX.Element;
 };
 
-type NonDefaultProps<T extends DatePicker.Value> = {
+type NonDefaultProps = {
   /** the label for the field */
   label: FormField.Props["label"];
   /** whether the field is required */
@@ -18,30 +17,24 @@ type NonDefaultProps<T extends DatePicker.Value> = {
   viewProps?: FormField.Props["viewProps"];
   /** an optional hint describing what's the expected value for the field (e.g. sample value or short description) */
   hint?: FormField.Props["hint"];
+  /** An optional custom renderer for DatePicker */
+  datePickerRenderer?: (props: DatePicker.Props) => JSX.Element;
   /** an optional class name to pass to top level element of the component */
   className?: string;
   /** an optional style object to pass to top level element of the component */
   style?: React.CSSProperties;
-} & ObjectOmit<
-  DatePicker.Props<T>,
-  "returnFormat"
->; /* returnFormat is causing issues with the inference of OnChangeProps */
+} & DatePicker.Props;
 
-type InternalProps<T extends DatePicker.Value> = DefaultProps<T> &
-  NonDefaultProps<T>;
+type InternalProps = DefaultProps & NonDefaultProps;
 
 export namespace DatePickerField {
-  export type Props<T extends DatePicker.Value> = NonDefaultProps<T> &
-    Partial<DefaultProps<T>>;
+  export type Props = NonDefaultProps & Partial<DefaultProps>;
 }
 
-export class DatePickerField<
-  T extends DatePicker.Value
-> extends React.PureComponent<InternalProps<T>> {
-  static defaultProps: DefaultProps<any> = {
+export class DatePickerField extends React.PureComponent<InternalProps> {
+  static defaultProps: DefaultProps = {
     datePickerRenderer: props => <DatePicker {...props} />
   };
-
   render() {
     const {
       label,
@@ -51,12 +44,11 @@ export class DatePickerField<
       id,
       disabled,
       hint,
-      onChange: _onChange,
+      onChange,
       datePickerRenderer,
       ..._datePickerProps
     } = this.props;
     const className = cx("date-picker-field", _className);
-    const onChange = _onChange as (value?: T) => void; // forcing onChange to be of type accepted if returnFormat is 'never'
     const datePickerProps = {
       ..._datePickerProps,
       onChange,


### PR DESCRIPTION
Closes #1347

## Test Plan

### tests performed

Example in showroom still works as expected