### PR TITLE
#1387: Allow to disable submit on enter in Form (closes #1387)

### DIFF
--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -7,6 +7,7 @@ import { findDOMNode, Children } from "../utils";
 export namespace Form {
   export type Props = View.Props & {
     render: (ref: React.RefObject<any>) => NonNullable<Children>;
+    noSubmitOnEnter: boolean;
   };
 }
 
@@ -14,7 +15,7 @@ export class Form extends React.PureComponent<Form.Props> {
   buttonRef = React.createRef<Button | StatefulButton>();
 
   onFormSubmit: React.ReactEventHandler<HTMLFormElement> = e => {
-    if (this.buttonRef.current) {
+    if (!this.props.noSubmitOnEnter && this.buttonRef.current) {
       const buttonDiv = findDOMNode(this.buttonRef.current);
       const clickable = buttonDiv.querySelector(".button-inner");
       if (clickable) {


### PR DESCRIPTION
Closes #1387

## Test Plan

Tested in preview:
* `noSubmitOnEnter` actually disables submit on enter
* Submit button still works, since handled outside the scope of `Form`


![2019-11-11 18 46 52](https://user-images.githubusercontent.com/6418684/68608727-e3756480-04b3-11ea-963c-6dd1b5973c26.gif)
