### PR TITLE
#1405: React missing unique key warning in FormField (closes #1405)

### DIFF
--- a/src/FormField/FormField.tsx
+++ b/src/FormField/FormField.tsx
@@ -67,16 +67,19 @@ export class FormField extends React.PureComponent<FormField.Props, State> {
     render: FormField.Props["render"],
     hint: FormField.Props["hint"]
   ) => {
-    const Field = render(
-      this.stateChange("focused", true),
-      this.stateChange("focused", false)
+    const Field = (
+      <React.Fragment key="no-hint">
+        {render(
+          this.stateChange("focused", true),
+          this.stateChange("focused", false)
+        )}
+      </React.Fragment>
     );
-
     if (hint) {
       switch (hint.type) {
         case "label":
           return (
-            <View grow column>
+            <View grow column key="label-hint">
               {Field}
               <View className={cx("form-field-hint", "form-field-hint-label")}>
                 {hint.content}
@@ -85,7 +88,7 @@ export class FormField extends React.PureComponent<FormField.Props, State> {
           );
         case "box":
           return (
-            <View grow>
+            <View grow key="box-hint">
               {Field}
               <View
                 shrink={false}
@@ -98,7 +101,7 @@ export class FormField extends React.PureComponent<FormField.Props, State> {
         case "tooltip":
           return (
             <Popover
-              key="popover"
+              key="popover-hint"
               className={cx("form-field-hint", "form-field-hint-tooltip")}
               popover={{
                 position: "right",

--- a/src/FormattedText/FormattedText.tsx
+++ b/src/FormattedText/FormattedText.tsx
@@ -72,12 +72,16 @@ export class FormattedText extends React.PureComponent<FormattedText.Props> {
     const paragraphs = children.split(/\n/g);
     return flattenDeep(
       paragraphs.map((paragraph, i) => {
+        const br = <br key={`br-${i}`} />;
+        const p = (
+          <React.Fragment key={`paragraph-${i}`}>{paragraph}</React.Fragment>
+        );
         if (paragraph.length === 0) {
-          return <br />;
+          return br;
         } else if (i < paragraphs.length - 1) {
-          return [paragraph, <br />];
+          return [p, br];
         } else {
-          return paragraph;
+          return p;
         }
       })
     );


### PR DESCRIPTION
Closes #1405

## Test Plan

No more warning for `FormField`:
![image](https://user-images.githubusercontent.com/6418684/69174209-a0457200-0b01-11ea-9ba4-6f704b8cfae1.png)

No more warning for `FormattedText` too:
![image](https://user-images.githubusercontent.com/6418684/69174159-8dcb3880-0b01-11ea-8cd3-29d7d9553264.png)

