### PR TITLE
#1410: MultiDropdownWithSelectAll defects when options are loaded async (closes #1410)

### DIFF
--- a/src/Dropdown/Examples.md
+++ b/src/Dropdown/Examples.md
@@ -180,6 +180,61 @@ const options = [
 />;
 ```
 
+#### Async options
+
+It is also possible to load the dropdown options asynchronously as the user types in the search input box:
+
+```js
+initialState = {
+  options: [],
+  value: null,
+  loading: false
+};
+
+var timeout = null;
+
+const generateOptions = searchString =>
+  searchString
+    ? Array.from({ length: 5 }, (_, k) => ({
+        value: searchString + k,
+        label: searchString + k
+      }))
+    : [];
+
+const onInputChange = inputString => {
+  if (timeout) {
+    clearTimeout(timeout);
+  }
+  if (inputString) {
+    setState({ loading: true });
+    timeout = setTimeout(() => {
+      setState({ options: generateOptions(inputString), loading: false });
+    }, 2000);
+  } else {
+    setState({ options: [] });
+  }
+};
+
+const onChange = newVal => {
+  if (newVal.type === "AllSelected") {
+    console.log("ALL selected!");
+  }
+  setState({ value: newVal });
+};
+
+<MultiDropdownWithSelectAll
+  className="custom"
+  value={state.value}
+  isSearchable
+  onChange={onChange}
+  onInputChange={onInputChange}
+  placeholder="Select some fruit(s)"
+  options={state.options}
+  selectAllLabel="All"
+  isLoading={state.loading}
+/>;
+```
+
 #### Groups
 
 Dropdown could also allow the grouping


### PR DESCRIPTION
Closes #1410

## Test Plan

### tests performed
New example added.
Tested:
- the `All` option is already visible before the user starts typing
- It's possible to type a search string even when the `All` option is selected
- The input doesn't lose focus when the options are loaded

![](https://i.gyazo.com/1e1c681669377142d2ca04e49fabfe53.gif)