### PR TITLE
#1360: proposal: remove runtime prop types checking (closes #1360)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,6 @@
     "react-select": "2.4.1",
     "react-transition-group": "1.2.0",
     "sass-flex-mixins": "0.1.0",
-    "tcomb": "3.2.22",
-    "tcomb-react": "0.9.3",
     "tlds": "1.194.0"
   },
   "devDependencies": {

--- a/src/AsyncStatusIndicator/AsyncStatusIndicator.tsx
+++ b/src/AsyncStatusIndicator/AsyncStatusIndicator.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { props, t, ReactElement } from "../utils";
 import * as cx from "classnames";
 import View from "react-flexview";
 
@@ -23,21 +22,7 @@ export namespace AsyncStatusIndicator {
   };
 }
 
-export const AsyncStatusIndicatorState = t.enums.of(
-  ["ready", "processing", "success", "error"],
-  "AsyncStatusIndicatorState"
-);
-
-export const Props = {
-  state: AsyncStatusIndicatorState,
-  icons: t.dict(AsyncStatusIndicatorState, ReactElement),
-  labels: t.dict(AsyncStatusIndicatorState, t.String),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
-
 /** A component that shows the status of an async operation */
-@props(Props)
 export class AsyncStatusIndicator extends React.PureComponent<
   AsyncStatusIndicator.Props
 > {

--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as cx from "classnames";
-import { props, t, ReactNode, Children } from "../utils";
+import { Children } from "../utils";
 import FlexView from "react-flexview";
 
 export namespace Badge {
@@ -16,14 +16,6 @@ export namespace Badge {
   };
 }
 
-export const Props = {
-  label: ReactNode,
-  active: t.maybe(t.Boolean),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
-
-@props(Props)
 export class Badge extends React.PureComponent<Badge.Props> {
   render() {
     const { label, active, className: _className, style } = this.props;

--- a/src/BrowserDetector/BrowserDetector.tsx
+++ b/src/BrowserDetector/BrowserDetector.tsx
@@ -1,40 +1,6 @@
 import * as React from "react";
 import some = require("lodash/some");
-import { props, t, ReactChildren } from "../utils";
 import * as bowser from "bowser";
-
-const browsers: bowser.IBowserVersions = {
-  chrome: true,
-  firefox: true,
-  msie: true,
-  msedge: true,
-  safari: true,
-  android: true,
-  ios: true,
-  opera: true,
-  phantom: true,
-  blackberry: true,
-  webos: true,
-  silk: true,
-  bada: true,
-  tizen: true,
-  seamonkey: true,
-  sailfish: true,
-  ucbrowser: true,
-  qupzilla: true,
-  vivaldi: true,
-  sleipnir: true,
-  kMeleon: true
-};
-
-export const Props = {
-  children: ReactChildren,
-  placeholder: t.Function,
-  supportedBrowsers: t.maybe(
-    t.list(t.enums.of(Object.keys(browsers), "Browser"))
-  ),
-  userAgent: t.maybe(t.String)
-};
 
 export namespace BrowserDetector {
   export type Browser = keyof bowser.IBowserVersions;
@@ -55,7 +21,6 @@ export namespace BrowserDetector {
  * Top-level component which detects browser and renders children/placeholder
  * based on a given whitelist of supported browsers.
  */
-@props(Props)
 export class BrowserDetector extends React.PureComponent<
   BrowserDetector.Props
 > {

--- a/src/Button/StatefulButton.tsx
+++ b/src/Button/StatefulButton.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import pick = require("lodash/pick");
-import { props, t, ObjectOmit } from "../utils";
-import { Button, ButtonPropTypes } from "./Button";
+import { ObjectOmit } from "../utils";
+import { Button } from "./Button";
+import { warn } from "../utils/log";
 
 // const PromiseType = t.irreducible('Promise', x => x instanceof Promise);
 
@@ -68,12 +68,6 @@ export type State = {
   internalState: "error" | "processing" | "success" | null;
 };
 
-@props({
-  ...ButtonPropTypes,
-  baseState: t.maybe(t.enums.of(["ready", "success", "not-allowed"])),
-  stableSuccess: t.maybe(t.Boolean),
-  timerMillis: t.maybe(t.Number)
-})
 export class StatefulButton extends React.PureComponent<
   StatefulButton.Props,
   State
@@ -115,7 +109,11 @@ export class StatefulButton extends React.PureComponent<
 
   componentWillReceiveProps(props: StatefulButton.Props) {
     if (process.env.NODE_ENV !== "production") {
-      t.assert(props.stableSuccess === this.props.stableSuccess);
+      if (props.stableSuccess !== this.props.stableSuccess) {
+        warn(
+          'StatefulButton: changing the "stableSuccess" prop is not supported'
+        );
+      }
     }
 
     if (props.buttonState) {
@@ -190,11 +188,19 @@ export class StatefulButton extends React.PureComponent<
   };
 
   render() {
-    const buttonProps: Button.Props = {
-      ...pick(this.props, Object.keys(ButtonPropTypes) as [keyof Button.Props]),
-      onClick: this.onClick
-    };
+    const {
+      baseState,
+      stableSuccess,
+      timerMillis,
+      ...buttonProps
+    } = this.props;
 
-    return <Button {...buttonProps} buttonState={this.getButtonState()} />;
+    return (
+      <Button
+        {...buttonProps}
+        onClick={this.onClick}
+        buttonState={this.getButtonState()}
+      />
+    );
   }
 }

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import * as cx from "classnames";
 import FlexView from "react-flexview";
-import { props, t } from "../utils";
 
 export type CheckboxRequiredProps = {
   /** value */
@@ -30,20 +29,6 @@ export namespace Checkbox {
   export type Props = CheckboxRequiredProps & Partial<CheckboxDefaultProps>;
 }
 
-export const Props = {
-  value: t.Boolean,
-  onChange: t.Function,
-  text: t.maybe(t.String),
-  onFocus: t.maybe(t.Function),
-  onBlur: t.maybe(t.Function),
-  disabled: t.maybe(t.Boolean),
-  readOnly: t.maybe(t.Boolean),
-  className: t.maybe(t.String),
-  id: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
-
-@props(Props)
 export class Checkbox extends React.PureComponent<Checkbox.Props> {
   static defaultProps: CheckboxDefaultProps = {
     disabled: false,

--- a/src/DateField/DateField.tsx
+++ b/src/DateField/DateField.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { props, t } from "../utils";
 import every = require("lodash/every");
 import * as cx from "classnames";
 import View from "react-flexview";
@@ -37,20 +36,6 @@ export type State = {
   isValid: boolean;
 };
 
-export const Props = {
-  value: t.maybe(t.Date),
-  onChange: t.Function,
-  onValidChange: t.maybe(t.Function),
-  placeholders: t.maybe(
-    t.struct({
-      day: t.maybe(t.String),
-      month: t.maybe(t.String),
-      year: t.maybe(t.String)
-    })
-  ),
-  inputTypeNumber: t.maybe(t.Boolean)
-};
-
 function parseDate(date: Date) {
   return {
     day: String(date.getDate()),
@@ -70,7 +55,6 @@ const initialState: State = {
 /**
  *  A simple component used to visually divide UI elements
  */
-@props(Props)
 export class DateField extends React.PureComponent<DateField.Props, State> {
   state = this.props.value
     ? {

--- a/src/Divider/Divider.tsx
+++ b/src/Divider/Divider.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { props, t } from "../utils";
 import * as cx from "classnames";
 
 export type DividerDefaultProps = {
@@ -20,23 +19,9 @@ export namespace Divider {
 }
 type DividerDefaultedProps = DividerDefaultProps;
 
-const orientation = t.enums.of(["horizontal", "vertical"], "orientation");
-const sizeType = t.enums.of(
-  ["small", "medium", "large", "no-margin"],
-  "sizeType"
-);
-
-export const Props = {
-  orientation: t.maybe(orientation),
-  style: t.maybe(t.Object),
-  size: t.maybe(sizeType),
-  className: t.maybe(t.String)
-};
-
 /**
  * A simple component used to visually divide UI elements
  */
-@props(Props)
 export class Divider extends React.PureComponent<Divider.Props> {
   static defaultProps: DividerDefaultProps = {
     orientation: "vertical",

--- a/src/FocusableView/FocusableView.tsx
+++ b/src/FocusableView/FocusableView.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import * as cx from "classnames";
 import debounce = require("lodash/debounce");
 import { Children } from "../utils";
-import isFunction = require("lodash/isFunction");
 
 export type FocusableViewRequiredProps = {
   /** FocusableView content. If a function it gets called with the boolean "focused" */
@@ -121,7 +120,7 @@ export class FocusableView extends React.Component<FocusableView.Props> {
     return React.createElement(
       component as any,
       locals,
-      isFunction(children) ? children(focused) : children
+      typeof children === "function" ? children(focused) : children
     );
   }
 }

--- a/src/FocusableView/FocusableView.tsx
+++ b/src/FocusableView/FocusableView.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import * as cx from "classnames";
 import debounce = require("lodash/debounce");
-import { props, t, ReactChildren, Children } from "../utils";
+import { Children } from "../utils";
+import isFunction = require("lodash/isFunction");
 
 export type FocusableViewRequiredProps = {
   /** FocusableView content. If a function it gets called with the boolean "focused" */
@@ -33,22 +34,9 @@ export namespace FocusableView {
 type FocusableViewDefaultedProps = FocusableViewRequiredProps &
   FocusableViewDefaultProps;
 
-export const Props = {
-  children: t.union([ReactChildren, t.Function]),
-  onFocus: t.maybe(t.Function),
-  onBlur: t.maybe(t.Function),
-  tabIndex: t.maybe(t.Number),
-  component: t.maybe(t.union([t.Function, t.String])),
-  ignoreFocus: t.maybe(t.Boolean),
-  debounce: t.maybe(t.Integer),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
-
 /**
  * A panel that can get focus
  */
-@props(Props, { strict: false })
 export class FocusableView extends React.Component<FocusableView.Props> {
   static defaultProps: FocusableViewDefaultProps = {
     ignoreFocus: false,
@@ -104,7 +92,7 @@ export class FocusableView extends React.Component<FocusableView.Props> {
   );
 
   onFocusBlurEvent = ({ type }: React.FocusEvent<HTMLElement>) =>
-    !t.Nil.is(this.defaultedProps().debounce)
+    this.defaultedProps().debounce != null
       ? this.onFocusBlurEventDebounced(type)
       : this._onFocusBlurEvent(type);
 
@@ -133,7 +121,7 @@ export class FocusableView extends React.Component<FocusableView.Props> {
     return React.createElement(
       component as any,
       locals,
-      t.Function.is(children) ? children(focused) : children
+      isFunction(children) ? children(focused) : children
     );
   }
 }

--- a/src/FormattedText/FormattedText.tsx
+++ b/src/FormattedText/FormattedText.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { props, t } from "../utils";
 import flattenDeep = require("lodash/flattenDeep");
 import * as _linkify from "linkify-it";
 import { LinkifyIt } from "linkify-it";
@@ -21,15 +20,6 @@ export namespace FormattedText {
   };
 }
 
-export const Props = {
-  children: t.String,
-  linkify: t.maybe(t.Boolean),
-  id: t.maybe(t.String),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
-
-@props(Props)
 export class FormattedText extends React.PureComponent<FormattedText.Props> {
   linkify(string: string): React.ReactNode {
     const matches = linkify.match(string);
@@ -59,7 +49,7 @@ export class FormattedText extends React.PureComponent<FormattedText.Props> {
   replaceLinksWithA(children: React.ReactNode[]): React.ReactNode[] {
     return flattenDeep(
       children.map(child => {
-        if (t.String.is(child)) {
+        if (typeof child === "string") {
           return this.linkify(child);
         } else {
           return child;

--- a/src/Image/Image.tsx
+++ b/src/Image/Image.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { props, t } from "../utils";
 import getUrl from "./getUrl";
 
 export namespace Image {
@@ -17,16 +16,7 @@ export namespace Image {
   } & React.HTMLAttributes<HTMLImageElement>;
 }
 
-export const Props = {
-  src: t.String,
-  width: t.maybe(t.Number),
-  height: t.maybe(t.Number),
-  quality: t.maybe(t.union([t.Number, t.enums.of(["auto"])])),
-  format: t.maybe(t.enums.of(["jpeg", "png", "wdp", "gif", "auto"]))
-};
-
 /** A replacement for `<img>` to serve optimized images through a CDN in production */
-@props(Props, { strict: false })
 export class Image extends React.Component<Image.Props> {
   render() {
     const { src, width, height, quality, ...props } = this.props;

--- a/src/Input/ConfirmationInput.tsx
+++ b/src/Input/ConfirmationInput.tsx
@@ -1,10 +1,8 @@
 import * as React from "react";
 import * as cx from "classnames";
-import { props, t } from "../utils";
 import omit = require("lodash/omit");
 import { Input } from "../Input/Input";
 import FlexView from "react-flexview";
-import { ReactChild } from "tcomb-react";
 
 export type ConfirmationInputRequiredProps = {
   /** input placeholder */
@@ -56,33 +54,12 @@ export namespace ConfirmationInput {
 type ConfirmationInputDefaultedProps = ConfirmationInputRequiredProps &
   ConfirmationInputDefaultProps;
 
-export const Props = {
-  initialValue: t.maybe(t.String),
-  onChange: t.maybe(t.Function),
-  onConfirm: t.maybe(t.Function),
-  onClear: t.maybe(t.Function),
-  placeholder: t.maybe(t.String),
-  disabled: t.maybe(t.Boolean),
-  text: t.struct({
-    clear: t.maybe(t.String),
-    toConfirm: t.maybe(t.String)
-  }),
-  icon: t.struct({
-    clear: t.maybe(ReactChild),
-    toConfirm: t.maybe(ReactChild)
-  }),
-  className: t.maybe(t.String),
-  id: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
-
 export type State = {
   focused: boolean;
   hoveringConfirm: boolean;
   value: string;
 };
 
-@props(Props, { strict: false })
 export class ConfirmationInput extends React.PureComponent<
   ConfirmationInput.Props,
   State

--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -1,12 +1,11 @@
 import * as React from "react";
 import * as cx from "classnames";
-import { props, t, ReactChildren, ObjectOverwrite, Children } from "../utils";
+import { ObjectOverwrite, Children } from "../utils";
 import omit = require("lodash/omit");
 import InputChildren from "react-input-children";
 import View from "react-flexview";
 
 export type InputStatus = "success" | "failure";
-const InputStatusT = t.enums.of(["success", "failure"]);
 
 export type InputRequiredProps = ObjectOverwrite<
   InputChildren.Props,
@@ -47,19 +46,6 @@ const failureIcon = (
   </svg>
 );
 
-export const Props = {
-  value: t.String,
-  onChange: t.Function,
-  placeholder: t.maybe(t.String),
-  disabled: t.maybe(t.Boolean),
-  className: t.maybe(t.String),
-  id: t.maybe(t.String),
-  style: t.maybe(t.Object),
-  children: t.maybe(ReactChildren),
-  status: t.maybe(InputStatusT)
-};
-
-@props(Props, { strict: false })
 export class Input extends React.PureComponent<Input.Props> {
   static defaultProps: InputDefaultProps = {
     disabled: false

--- a/src/Input/PasswordInput.tsx
+++ b/src/Input/PasswordInput.tsx
@@ -1,11 +1,5 @@
 import * as React from "react";
-import { props, t } from "../utils";
-import {
-  Input,
-  InputRequiredProps,
-  InputDefaultProps,
-  Props as InputPropsT
-} from "../Input/Input";
+import { Input, InputRequiredProps, InputDefaultProps } from "../Input/Input";
 import View from "react-flexview";
 
 export type PasswordInputRequiredProps = InputRequiredProps;
@@ -24,17 +18,10 @@ export namespace PasswordInput {
 type PasswordInputDefaultedProps = PasswordInputRequiredProps &
   PasswordInputDefaultProps;
 
-export const Props = {
-  ...InputPropsT,
-  hideText: t.maybe(t.String),
-  showText: t.maybe(t.String)
-};
-
 export type State = {
   show: boolean;
 };
 
-@props(Props, { strict: false })
 export class PasswordInput extends React.PureComponent<
   PasswordInput.Props,
   State

--- a/src/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/LoadingSpinner/LoadingSpinner.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as cx from "classnames";
-import { props, t } from "../utils";
 import { warn } from "../utils/log";
 
 export type LoadingSpinnerDefaultProps = {
@@ -31,26 +30,9 @@ export namespace LoadingSpinner {
 type LoadingSpinnerDefaultedProps = LoadingSpinnerRequiredProps &
   LoadingSpinnerDefaultProps;
 
-export const Props = {
-  size: t.maybe(t.union([t.String, t.Number])),
-  color: t.maybe(t.String),
-  message: t.maybe(
-    t.struct({
-      content: t.String,
-      color: t.maybe(t.String),
-      size: t.maybe(t.union([t.String, t.Number]))
-    })
-  ),
-  overlayColor: t.maybe(t.String),
-  id: t.maybe(t.String),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
-
 /**
  * Absolute dimmed layer with loading spinner in the center
  */
-@props(Props)
 export class LoadingSpinner extends React.PureComponent<LoadingSpinner.Props> {
   private loadingSpinner: HTMLDivElement | null = null;
 

--- a/src/Menu/ActionsMenu.tsx
+++ b/src/Menu/ActionsMenu.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as cx from "classnames";
-import { props, t, ReactChildren } from "../utils";
 import partial = require("lodash/partial");
 import FlexView from "react-flexview";
 import { Divider } from "../Divider/Divider";
@@ -36,31 +35,11 @@ export type State = {
   height: number | null;
 };
 
-export const optionType = t.struct(
-  {
-    type: t.enums.of(["title", "item", "divider"]),
-    title: t.maybe(ReactChildren),
-    metadata: t.Any,
-    selected: t.maybe(t.Boolean),
-    disabled: t.maybe(t.Boolean),
-    onClick: t.maybe(t.Function)
-  },
-  "optionType"
-);
-
-export const Props = {
-  style: t.maybe(t.Object),
-  maxHeight: t.maybe(t.Number),
-  options: t.maybe(t.list(optionType)),
-  onClick: t.maybe(t.Function)
-};
-
 const defaultProps: ActionsMenuDefaultProps = {
   style: {},
   onClick: () => {}
 };
 
-@props(Props)
 export class ActionsMenu extends React.PureComponent<ActionsMenu.Props, State> {
   constructor(props: ActionsMenu.Props) {
     super(props);

--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
-import { props, t, ReactChildren } from "../utils";
-import { ActionsMenu, optionType } from "./ActionsMenu";
+import { ActionsMenu } from "./ActionsMenu";
 import FlexView from "react-flexview";
 import { Popover } from "../Popover/Popover";
 import * as cx from "classnames";
@@ -39,24 +38,9 @@ export namespace Menu {
 }
 type MenuDefaultedProps = MenuRequiredProps & MenuDefaultProps;
 
-export const Props = {
-  children: t.maybe(ReactChildren),
-  menuRenderer: t.maybe(t.Function),
-  options: t.list(optionType),
-  isOpen: t.maybe(t.Boolean),
-  onOpen: t.Function,
-  onClose: t.Function,
-  dismissOnClickOutside: t.maybe(t.Boolean),
-  size: t.maybe(t.enums.of(["small", "medium", "large"])),
-  position: t.maybe(t.enums.of(["top", "bottom"])),
-  maxHeight: t.maybe(t.Number),
-  className: t.maybe(t.String)
-};
-
 /**
  *  A menu with actions
  */
-@props(Props)
 export class Menu extends React.PureComponent<Menu.Props> {
   static defaultProps: MenuDefaultProps = {
     isOpen: false,

--- a/src/MobileDetector/MobileDetector.tsx
+++ b/src/MobileDetector/MobileDetector.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as MobileDetect from "mobile-detect";
-import { props, t } from "../utils";
 import * as PropTypes from "prop-types";
 
 export namespace MobileDetector {
@@ -21,16 +20,9 @@ export namespace MobileDetector {
   };
 }
 
-export const Props = {
-  children: t.Function,
-  forceDesktop: t.maybe(t.Boolean),
-  userAgent: t.maybe(t.String)
-};
-
 /**
  * Top-level component which detects device type and passes this info to children as context
  */
-@props(Props)
 export class MobileDetector extends React.Component<MobileDetector.Props> {
   static childContextTypes = {
     isDesktop: PropTypes.bool.isRequired,

--- a/src/Modal/BackgroundDimmer.tsx
+++ b/src/Modal/BackgroundDimmer.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
 import * as cx from "classnames";
-import { props, t, ReactChildren } from "../utils";
 import FlexView from "react-flexview";
 import omit = require("lodash/omit");
-import { findDOMNode } from "../utils";
+import { findDOMNode, Children } from "../utils";
 
 export type BackgroundDimmerRequiredProps = {
   /** children nodes/elements */
-  children: any; // TODO: t.ReactChildren
+  children: Children;
   /** called when user clicks outside children */
   onClickOutside?: (e: React.SyntheticEvent<HTMLDivElement>) => void;
   /** component's class */
@@ -45,23 +44,6 @@ export namespace BackgroundDimmer {
     Partial<BackgroundDimmerDefaultProps>;
 }
 
-export const Props = {
-  children: ReactChildren,
-  color: t.maybe(t.String),
-  alpha: t.maybe(t.Number),
-  zIndex: t.maybe(t.Number),
-  stopScrollPropagation: t.maybe(t.Boolean),
-  onClickOutside: t.maybe(t.Function),
-  width: t.maybe<string | number>(t.union([t.String, t.Number])),
-  maxWidth: t.maybe<string | number>(t.union([t.String, t.Number])),
-  height: t.maybe<string | number>(t.union([t.String, t.Number])),
-  maxHeight: t.maybe<string | number>(t.union([t.String, t.Number])),
-  className: t.maybe(t.String),
-  id: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
-
-@props(Props)
 export class BackgroundDimmer extends React.PureComponent<
   BackgroundDimmer.Props
 > {

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -46,28 +46,22 @@ export namespace Modal {
     Partial<ModalDefaultProps>;
 }
 
-const LocalProps = {
-  children: ReactChildren,
-  title: t.maybe(t.String),
-  footer: t.maybe(ReactChildren),
-  iconClose: t.maybe(ReactChild),
-  overlay: t.interface({
-    color: t.maybe(t.String),
-    alpha: t.maybe(t.Number)
-  }),
-  dismissOnClickOutside: t.maybe(t.Boolean),
-  onDismiss: t.maybe(t.Function),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object),
-  id: t.maybe(t.String)
+const LocalProps: Record<
+  keyof ModalRequiredProps | keyof ModalDefaultProps,
+  true
+> = {
+  children: true,
+  title: true,
+  footer: true,
+  iconClose: true,
+  overlay: true,
+  dismissOnClickOutside: true,
+  onDismiss: true,
+  className: true,
+  style: true,
+  id: true
 };
 
-export const Props = {
-  ...PortalProps,
-  ...LocalProps
-};
-
-@props(Props)
 export class Modal extends React.Component<Modal.Props> {
   static defaultProps: ModalDefaultProps = {
     onDismiss: () => {},

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import * as cx from "classnames";
-import { props, t, ReactChildren, ReactChild } from "../utils";
 import omit = require("lodash/omit");
-import { ModalPortal, Props as PortalProps } from "./ModalPortal";
+import { ModalPortal } from "./ModalPortal";
 import FlexView from "react-flexview";
 import { BackgroundDimmer } from "./BackgroundDimmer";
 

--- a/src/Modal/ModalPortal.tsx
+++ b/src/Modal/ModalPortal.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as ReactTransitionGroup from "react-transition-group/TransitionGroup";
-import { props, t, ReactChildren } from "../utils";
 import TransitionWrapper from "../TransitionWrapper";
 
 let containerNode: Element | null = null;
@@ -21,21 +20,11 @@ export namespace ModalPortal {
   };
 }
 
-export const Props = {
-  children: ReactChildren,
-  transitionEnterTimeout: t.Number,
-  transitionLeaveTimeout: t.Number,
-  className: t.maybe(t.String),
-  childContextTypes: t.maybe(t.Object),
-  getChildContext: t.maybe(t.Function)
-};
-
 type ContextWrapperProps = {
   modal: () => JSX.Element;
   getChildContext?: () => object;
 };
 
-@props(Props)
 export class ModalPortal extends React.Component<ModalPortal.Props> {
   private isOpen: boolean = false;
 

--- a/src/MoreOrLess/MoreOrLess.tsx
+++ b/src/MoreOrLess/MoreOrLess.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import * as cx from "classnames";
-import { props, t, ReactChildren, ReactChild } from "../utils";
 import FlexView from "react-flexview";
+import { Children } from "../utils";
 
 export namespace MoreOrLess {
   export type Props = {
     /** panel content */
-    children: any; // TODO: t.ReactChildren
+    children: Children;
     /** whether the panel should be expanded or not */
     expanded: boolean;
     /** called on toggle */
@@ -25,23 +25,9 @@ export namespace MoreOrLess {
   };
 }
 
-export const Props = {
-  children: ReactChildren,
-  expanded: t.Boolean,
-  onExpandedChange: t.Function,
-  icons: t.struct({
-    expanded: ReactChild,
-    collapsed: ReactChild
-  }),
-  wrapperProps: t.maybe(t.Object),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
-
 /**
  * A panel used to alternately display short or long version of the content
  */
-@props(Props)
 export class MoreOrLess extends React.PureComponent<MoreOrLess.Props> {
   toggleExpanded = () => {
     this.props.onExpandedChange(!this.props.expanded);

--- a/src/NavBar/NavBar.tsx
+++ b/src/NavBar/NavBar.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as cx from "classnames";
-import { props, t, ReactChildren, Children } from "../utils";
+import { Children } from "../utils";
 import FlexView from "react-flexview";
 
 export namespace NavBar {
@@ -28,21 +28,6 @@ export namespace NavBar {
   };
 }
 
-export const Props = {
-  content: t.struct({
-    left: t.maybe(ReactChildren),
-    center: t.maybe(ReactChildren),
-    right: t.maybe(ReactChildren),
-    maxWidth: t.maybe(t.union([t.String, t.Number]))
-  }),
-  fixed: t.maybe(t.Boolean),
-  height: t.maybe(t.union([t.String, t.Number])),
-  background: t.maybe(t.String),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
-
-@props(Props)
 export class NavBar extends React.PureComponent<NavBar.Props> {
   render() {
     const {

--- a/src/Overflow/Overflow.tsx
+++ b/src/Overflow/Overflow.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { props, t, ReactElement } from "../utils";
 import { ResizeSensor } from "../ResizeSensor/ResizeSensor";
 
 export namespace Overflow {
@@ -18,16 +17,7 @@ export type State = {
   isOverflowing: boolean;
 };
 
-export const Props = {
-  content: ReactElement,
-  contentIfOverflowing: ReactElement,
-  id: t.maybe(t.String),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
-
 /** Util component to render a different react node if the original one overflows its parent. */
-@props(Props)
 export class Overflow extends React.Component<Overflow.Props, State> {
   private ref: HTMLDivElement | null = null;
 

--- a/src/Panel/Panel.tsx
+++ b/src/Panel/Panel.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as cx from "classnames";
-import { props, t, ReactChildren, Children } from "../utils";
-import { PanelHeader, HeaderSize } from "./PanelHeader";
+import { Children } from "../utils";
+import { PanelHeader } from "./PanelHeader";
 import capitalize = require("lodash/capitalize");
 import { LoadingSpinner } from "../LoadingSpinner/LoadingSpinner";
 import FlexView from "react-flexview";
@@ -48,54 +48,16 @@ export namespace Panel {
       isCollapsed?: boolean;
     };
     size?: PanelHeader.Props["size"];
-    content?: any; // TODO: t.ReactChildren
+    content?: Children;
     title?: any; // TODO(typo): wtf
     hideTitleWhenExpanded?: boolean;
-    menu?: any; // TODO: t.ReactChildren
+    menu?: Children;
   };
 
   export type Props = PanelRequiredProps & Partial<PanelDefaultProps>;
 }
 
-export const Props = {
-  type: t.enums.of([
-    "docked-top",
-    "docked-left",
-    "docked-right",
-    "docked-bottom",
-    "floating"
-  ]),
-  header: t.maybe(
-    t.struct({
-      collapse: t.maybe(
-        t.struct({
-          direction: t.enums.of(["up", "left", "right", "down"]),
-          onExpand: t.Function,
-          onCollapse: t.Function,
-          isCollapsed: t.maybe(t.Boolean)
-        })
-      ),
-      size: t.maybe(HeaderSize),
-      content: t.maybe(ReactChildren),
-      title: t.maybe(ReactChildren),
-      hideTitleWhenExpanded: t.maybe(t.Boolean),
-      menu: t.maybe(ReactChildren)
-    })
-  ),
-  loading: t.maybe(t.Boolean),
-  dark: t.maybe(t.Boolean),
-  softLoading: t.maybe(t.Boolean),
-  softLoadingDelay: t.maybe(
-    t.refinement(t.Number, v => v >= 0, "NonNegativeNumber")
-  ),
-  children: ReactChildren,
-  className: t.maybe(t.String),
-  clearMargin: t.maybe(t.enums.of(["top", "left", "right", "bottom"])),
-  style: t.maybe(t.Object)
-};
-
 /** A simple component used to group elements in a box. */
-@props(Props)
 export class Panel extends React.PureComponent<Panel.Props> {
   static defaultProps: PanelDefaultProps = {
     style: {},

--- a/src/Panel/PanelHeader.tsx
+++ b/src/Panel/PanelHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { props, t, stateClassUtil, ReactChildren, Children } from "../utils";
+import { stateClassUtil, Children } from "../utils";
 import FlexView from "react-flexview";
 import * as cx from "classnames";
 
@@ -82,22 +82,6 @@ const icons = {
   right: [angleRightIcon, angleLeftIcon]
 };
 
-const headerSizes = ["tiny", "small", "medium"];
-export const HeaderSize = t.enums.of(headerSizes, "HeaderSize");
-
-@props({
-  collapse: t.maybe(
-    t.struct({
-      isExpanded: t.Boolean,
-      direction: t.enums.of(Object.keys(icons)),
-      onToggleExpanded: t.Function
-    })
-  ),
-  size: HeaderSize,
-  title: t.maybe(ReactChildren),
-  content: t.maybe(ReactChildren),
-  menu: t.maybe(ReactChildren)
-})
 export class PanelHeader extends React.PureComponent<PanelHeader.Props> {
   static defaultProps: PanelHeaderDefaultProps = {
     size: "small"
@@ -119,12 +103,7 @@ export class PanelHeader extends React.PureComponent<PanelHeader.Props> {
     const renderTitle = !!title && renderInnerHeader;
     const renderContent = !!content && renderInnerHeader;
     const renderMenu = menu && renderInnerHeader;
-    const height =
-      size === HeaderSize("tiny")
-        ? 40
-        : size === HeaderSize("medium")
-        ? 56
-        : 48;
+    const height = size === "tiny" ? 40 : size === "medium" ? 56 : 48;
     const className = cx("panel-header", stateClassUtil([size]));
 
     return (

--- a/src/Panel/TabbedPanel.tsx
+++ b/src/Panel/TabbedPanel.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
 import * as cx from "classnames";
-import { props, t } from "../utils";
-import { Panel, Props as panelProps } from "./Panel";
+import { Panel } from "./Panel";
 import FlexView from "react-flexview";
 
 export namespace TabbedPanel {
   export type Tabs = {
     basis?: number;
-    headers: string[];
+    headers: string[] & { 0: string };
     activeIndex?: number;
     onSetActiveTab: (x: number) => void;
   };
@@ -17,20 +16,6 @@ export namespace TabbedPanel {
   } & Panel.Props;
 }
 
-export const Props = t.refinement(
-  t.struct({
-    ...panelProps,
-    tabs: t.struct({
-      basis: t.maybe(t.Number),
-      headers: t.list(t.String),
-      activeIndex: t.maybe(t.Number),
-      onSetActiveTab: t.maybe(t.Function)
-    })
-  }),
-  ({ tabs }: any) => tabs.headers.length > 0
-);
-
-@props(Props)
 export class TabbedPanel extends React.PureComponent<TabbedPanel.Props> {
   onSetActiveTab = (activeTabIndex: number) => {
     const {

--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -3,48 +3,9 @@ import * as ReactDOM from "react-dom";
 import * as cx from "classnames";
 import debounce = require("lodash/debounce");
 import uniq = require("lodash/uniq");
-import { props, t, ReactChildren, getContextWrapper, Children } from "../utils";
+import { getContextWrapper, Children } from "../utils";
 
 const NO_SIZE_WRAPPER = "no-size-wrapper";
-
-export const Props = {
-  children: ReactChildren,
-  popover: t.struct({
-    content: ReactChildren,
-    auto: t.maybe(t.Boolean),
-    attachToBody: t.maybe(t.Boolean),
-    position: t.maybe(t.enums.of(["top", "bottom", "left", "right"])),
-    anchor: t.maybe(t.enums.of(["start", "center", "end"])),
-    event: t.maybe(t.enums.of(["click", "hover"])),
-    onShow: t.maybe(t.Function),
-    onHide: t.maybe(t.Function),
-    onToggle: t.maybe(t.Function),
-    dismissOnScroll: t.maybe(t.Boolean),
-    dismissOnClickOutside: t.maybe(t.Boolean),
-    className: t.maybe(t.String),
-    style: t.maybe(t.Object),
-    id: t.maybe(t.String),
-    maxWidth: t.maybe(t.union([t.Number, t.String])),
-    distance: t.maybe(t.Number),
-    offsetX: t.maybe(t.Number),
-    offsetY: t.maybe(t.Number),
-    isOpen: t.maybe(t.Boolean),
-    delay: t.maybe(
-      t.union([
-        t.Integer,
-        t.interface({
-          whenClosed: t.maybe(t.Integer),
-          whenOpen: t.maybe(t.Integer)
-        })
-      ])
-    ),
-    contextTypes: t.maybe(t.Object),
-    context: t.maybe(t.Object)
-  }),
-  id: t.maybe(t.String),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
 
 export type State = {
   isOpen: boolean;
@@ -129,7 +90,6 @@ type PopoverStyle = React.CSSProperties & {
  * Composed of two children: trigger (children) and popover. After a particular event on the trigger
  * (usually "hover" or "click") it renders the popover and positions it relative to it.
  */
-@props(Props)
 export class Popover extends React.Component<Popover.Props, State> {
   private children: HTMLDivElement | null = null;
   private initialized: boolean = false;

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import * as cx from "classnames";
 import FlexView from "react-flexview";
-import { props, t } from "../utils";
 
 export type RadioOption = {
   label: string;
@@ -31,18 +30,6 @@ export namespace RadioGroup {
   export type Props = RadioGroupRequiredProps & Partial<RadioGroupDefaultProps>;
 }
 
-export const Props = {
-  value: t.maybe(t.String),
-  onChange: t.Function,
-  options: t.list(t.interface({ label: t.String, value: t.String })),
-  disabled: t.maybe(t.Boolean),
-  horizontal: t.maybe(t.Boolean),
-  className: t.maybe(t.String),
-  id: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
-
-@props(Props)
 export class RadioGroup extends React.PureComponent<RadioGroup.Props> {
   static defaultProps: RadioGroupDefaultProps = {
     disabled: false,

--- a/src/ResizeSensor/ResizeSensor.ts
+++ b/src/ResizeSensor/ResizeSensor.ts
@@ -1,14 +1,7 @@
 import * as React from "react";
 import _debounce = require("lodash/debounce");
-import { props, t, ReactChildren } from "../utils";
 import _ResizeSensor = require("css-element-queries/src/ResizeSensor");
 import { findDOMNode } from "../utils";
-
-export const Props = {
-  children: ReactChildren,
-  onResize: t.Function,
-  debounce: t.maybe(t.Integer)
-};
 
 export namespace ResizeSensor {
   export type Props = {
@@ -28,7 +21,6 @@ interface ResizeSensorElement extends Element {
 /**
  * A component that exposes an `onResize` callback called whenever his parent's size changes.
  */
-@props(Props)
 export class ResizeSensor extends React.Component<ResizeSensor.Props> {
   private elementQueries: boolean = false;
   private resizeSensor: {} | null = null;

--- a/src/Scroll/ScrollView.tsx
+++ b/src/Scroll/ScrollView.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import omit = require("lodash/omit");
 import { Children } from "../utils";
 import easing, { EasingType } from "./easingFunctions";
-import isFunction = require("lodash/isFunction");
 
 export type ScrollViewDefaultProps = {
   /** enable horizontal scrolling */
@@ -226,7 +225,9 @@ export class ScrollView extends React.Component<ScrollView.Props> {
           this.scrollView = sv;
         }}
       >
-        {isFunction(children) ? children(this.scrollTo) : children}
+        {typeof children === "function"
+          ? (children as any)(this.scrollTo)
+          : children}
       </div>
     );
   }

--- a/src/Scroll/ScrollView.tsx
+++ b/src/Scroll/ScrollView.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import omit = require("lodash/omit");
-import { props, t, ReactChildren, Children } from "../utils";
+import { Children } from "../utils";
 import easing, { EasingType } from "./easingFunctions";
+import isFunction = require("lodash/isFunction");
 
 export type ScrollViewDefaultProps = {
   /** enable horizontal scrolling */
@@ -38,14 +39,17 @@ export namespace ScrollView {
     React.HTMLAttributes<HTMLDivElement>;
 }
 
-export const Props = {
-  children: t.union([ReactChildren, t.Function]),
-  scrollX: t.maybe(t.Boolean),
-  scrollY: t.maybe(t.Boolean),
-  scrollPropagation: t.maybe(t.Boolean),
-  easing: t.maybe(t.enums.of(Object.keys(easing))),
-  onScroll: t.maybe(t.Function),
-  style: t.maybe(t.Object)
+const Props: Record<
+  keyof ScrollViewRequiredProps | keyof ScrollViewDefaultProps,
+  true
+> = {
+  children: true,
+  scrollX: true,
+  scrollY: true,
+  scrollPropagation: true,
+  easing: true,
+  onScroll: true,
+  style: true
 };
 
 /**
@@ -54,7 +58,6 @@ export const Props = {
  * - smooth programmatic scroll with 22 easing functions (see `easingFunctions.js`)
  * - out of the box momentum scrolling on iOS
  */
-@props(Props, { strict: false })
 export class ScrollView extends React.Component<ScrollView.Props> {
   private scrollView: HTMLDivElement | null = null;
   private lastY: number = 0;
@@ -176,8 +179,8 @@ export class ScrollView extends React.Component<ScrollView.Props> {
       const easingFunction = easing[easingType];
 
       if (
-        (t.Number.is(x) && scrollLeft !== x) ||
-        (t.Number.is(y) && scrollTop !== y)
+        (typeof x === "number" && scrollLeft !== x) ||
+        (typeof y === "number" && scrollTop !== y)
       ) {
         const currentTime = Math.min(scrollDuration, Date.now() - startTime);
         const distanceX = x - startX;
@@ -223,7 +226,7 @@ export class ScrollView extends React.Component<ScrollView.Props> {
           this.scrollView = sv;
         }}
       >
-        {t.Function.is(children) ? children(this.scrollTo) : children}
+        {isFunction(children) ? children(this.scrollTo) : children}
       </div>
     );
   }

--- a/src/ScrollView/ScrollView.tsx
+++ b/src/ScrollView/ScrollView.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as cx from "classnames";
-import { props, t, ReactChildren } from "../utils";
 import GeminiScrollbar = require("gemini-scrollbar");
 import { ResizeSensor } from "../ResizeSensor/ResizeSensor";
 import { findDOMNode } from "../utils";
@@ -45,20 +44,7 @@ export namespace ScrollView {
     Partial<ScrollViewDefaultProps<CP, ICP>>;
 }
 
-export const Props = {
-  children: ReactChildren,
-  autoshow: t.maybe(t.Boolean),
-  forceGemini: t.maybe(t.Boolean),
-  component: t.maybe(t.union([t.Function, t.String])),
-  componentProps: t.maybe(t.Object),
-  innerComponent: t.maybe(t.union([t.Function, t.String])),
-  innerComponentProps: t.maybe(t.Object),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
-
 /** A scrollable view to be used in projects where you want the same scrollbar style across different browsers */
-@props(Props)
 export class ScrollView<
   CP extends React.HTMLAttributes<any>,
   ICP extends React.HTMLAttributes<any>

--- a/src/Tablo/Cell/Cell.tsx
+++ b/src/Tablo/Cell/Cell.tsx
@@ -3,7 +3,6 @@ import * as cx from "classnames";
 import { Children } from "../../utils";
 import FlexView from "react-flexview";
 import { Cell as CellFDT } from "fixed-data-table-2";
-import isFunction = require("lodash/isFunction");
 
 export type Intrinsic<T, K> = {
   data: K extends keyof T ? T[K] : never;
@@ -85,7 +84,9 @@ export function Cell<T extends {}, K extends keyof T | never = never>(
           vAlignContent={vAlignContent}
           hAlignContent={hAlignContent}
         >
-          {isFunction(render) ? render(data, rowData, rowIndex) : render}
+          {typeof render === "function"
+            ? render(data, rowData, rowIndex)
+            : render}
         </FlexView>
       </FlexView>
     </CellFDT>

--- a/src/Tablo/Cell/Cell.tsx
+++ b/src/Tablo/Cell/Cell.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import * as cx from "classnames";
-import { props, t, ReactChildren, Children } from "../../utils";
+import { Children } from "../../utils";
 import FlexView from "react-flexview";
 import { Cell as CellFDT } from "fixed-data-table-2";
+import isFunction = require("lodash/isFunction");
 
 export type Intrinsic<T, K> = {
   data: K extends keyof T ? T[K] : never;
@@ -48,24 +49,7 @@ type CellDefaultedIntrinsicProps<T, K extends keyof T | never> = Required<
   Default &
   Intrinsic<T, K>;
 
-const { maybe, enums, union } = t;
-
-const propsTypes = {
-  data: t.Any,
-  fixed: maybe(t.Boolean),
-  rowData: t.Any,
-  rowIndex: maybe(t.Integer),
-  render: union([t.Function, ReactChildren]),
-  backgroundColor: maybe(t.String),
-  color: maybe(t.String),
-  vAlignContent: maybe(enums.of(["top", "center", "bottom"])),
-  hAlignContent: maybe(enums.of(["left", "center", "right"])),
-  contentStyle: maybe(t.Object),
-  style: maybe(t.Object),
-  grow: maybe(t.Boolean)
-};
-
-export function _Cell<T extends {}, K extends keyof T | never = never>(
+export function Cell<T extends {}, K extends keyof T | never = never>(
   props: Cell.Props<T, K>
 ): React.ReactElement<Cell.Props<T, K>> {
   const {
@@ -101,15 +85,11 @@ export function _Cell<T extends {}, K extends keyof T | never = never>(
           vAlignContent={vAlignContent}
           hAlignContent={hAlignContent}
         >
-          {t.Function.is(render) ? render(data, rowData, rowIndex) : render}
+          {isFunction(render) ? render(data, rowData, rowIndex) : render}
         </FlexView>
       </FlexView>
     </CellFDT>
   );
 }
-
-props(propsTypes)(_Cell);
-
-export const Cell = _Cell;
 
 export const defaultCell = <Cell<any, any> render={dataCell => dataCell} />;

--- a/src/Tablo/Column/Column.tsx
+++ b/src/Tablo/Column/Column.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import find = require("lodash/find");
-import { t, ReactChildren } from "../../utils";
 import { getArrayChildren } from "../utils";
 
 import { Column as ColumnFDT } from "fixed-data-table-2";
@@ -42,24 +41,7 @@ export type ColumnDefaultedIntrinsicProps<T> = Required<T> &
   Intrinsic<T>;
 export type ColumnIntrinsicProps<T extends {}> = Column.Props<T> & Intrinsic<T>;
 
-const { union, maybe, struct } = t;
 export const defaultWidth = 200;
-
-const argsTypes = struct(
-  {
-    key: union([t.String, t.Number]),
-    width: maybe(t.Number),
-    data: maybe(t.Array),
-    name: t.String,
-    fixed: maybe(t.Boolean),
-    flexGrow: maybe(t.Number),
-    children: ReactChildren,
-    allowCellsRecycling: maybe(t.Boolean),
-    sortable: maybe(t.Boolean),
-    isResizable: maybe(t.Boolean)
-  },
-  { strict: true }
-);
 
 export const Column = <T extends {}>(
   args: Column.Props<T>
@@ -74,7 +56,7 @@ export const Column = <T extends {}>(
     isResizable,
     children = [],
     allowCellsRecycling = true
-  } = argsTypes(args) as ColumnDefaultedIntrinsicProps<T>;
+  } = args as ColumnDefaultedIntrinsicProps<T>;
 
   const cell = ({
     rowIndex,

--- a/src/Tablo/ColumnGroup/ColumnGroup.tsx
+++ b/src/Tablo/ColumnGroup/ColumnGroup.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { t, ReactChildren } from "../../utils";
 import find = require("lodash/find");
 
 import { ColumnGroup as ColumnGroupFDT } from "fixed-data-table-2";
@@ -16,18 +15,8 @@ export namespace ColumnGroup {
   };
 }
 
-const { union, maybe, struct } = t;
-const argsTypes = struct(
-  {
-    key: union([t.String, t.Number]),
-    fixed: maybe(t.Boolean),
-    children: ReactChildren
-  },
-  { strict: true, name: "ColumnGroupProps" }
-);
-
 export function ColumnGroup<T>(args: ColumnGroup.Props<T>) {
-  const { key, fixed, children } = argsTypes(args) as ColumnGroup.Props<T>;
+  const { key, fixed, children } = args;
 
   const header =
     find(children, child => child.type === Header) || defaultHeader("");

--- a/src/Tablo/Footer/Footer.tsx
+++ b/src/Tablo/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import FlexView from "react-flexview";
-import { props, t, ReactChildren, Children } from "../../utils";
+import { Children } from "../../utils";
 
 export namespace Footer {
   export type Props = {
@@ -8,16 +8,6 @@ export namespace Footer {
   };
 }
 
-const { maybe } = t;
-
-const propsTypes = {
-  columnKey: maybe(t.String),
-  width: maybe(t.Number),
-  height: maybe(t.Number),
-  children: ReactChildren
-};
-
-@props(propsTypes)
 export class Footer extends React.PureComponent<Footer.Props> {
   render() {
     const { children } = this.props;

--- a/src/Tablo/Header/Header.tsx
+++ b/src/Tablo/Header/Header.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as cx from "classnames";
-import { props, t, ReactChildren, Children } from "../../utils";
+import { Children } from "../../utils";
 import FlexView from "react-flexview";
 
 export type FDTIntrinsic = {
@@ -19,19 +19,6 @@ export namespace Header {
 }
 export type HeaderIntrinsicProps = Header.Props & Intrinsic & FDTIntrinsic;
 
-const { maybe } = t;
-
-const propsTypes = {
-  children: ReactChildren,
-  rowIndex: maybe(t.Number),
-  columnKey: maybe(t.String),
-  width: maybe(t.Number),
-  fixed: maybe(t.Boolean),
-  height: maybe(t.Number),
-  onClick: maybe(t.Function)
-};
-
-@props(propsTypes)
 export class Header extends React.PureComponent<Header.Props> {
   render() {
     const { fixed, onClick: onClick, children } = this

--- a/src/Tablo/Tablo.tsx
+++ b/src/Tablo/Tablo.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as cx from "classnames";
-import { props, t, ReactChildren } from "../utils";
 import { Table, TableProps } from "fixed-data-table-2";
 import Column, { defaultColumns, updateColumns } from "./Column";
 import FlexView from "react-flexview";
@@ -14,6 +13,7 @@ import {
   sortable
 } from "./plugins";
 import omit = require("lodash/omit");
+import { warn } from "../utils/log";
 
 import "./patch-fixed-data-table-2";
 
@@ -107,34 +107,6 @@ export namespace Tablo {
     Partial<TabloDefaultProps>;
 }
 
-const { maybe } = t;
-@props({
-  // public
-  autosize: maybe(t.Boolean),
-  className: maybe(t.String),
-  data: t.Array,
-  width: t.Number,
-  height: t.Number,
-  rowHeight: maybe(t.Number),
-  headerHeight: maybe(t.Number),
-  groupHeaderHeight: maybe(t.Number),
-  footerHeight: maybe(t.Number),
-  onRowMouseEnter: maybe(t.Function),
-  onRowMouseLeave: maybe(t.Function),
-  scrollLeft: maybe(t.Integer),
-  scrollTop: maybe(t.Integer),
-  onScrollStart: maybe(t.Function),
-  onScrollEnd: maybe(t.Function),
-  children: ReactChildren,
-  rowClassNameGetter: maybe(t.Function),
-  touchScrollEnabled: maybe(t.Boolean),
-
-  // private
-  scrollToRow: maybe(t.Integer),
-  onRowClick: maybe(t.Function),
-  onColumnResizeEndCallback: maybe(t.Function),
-  isColumnResizing: maybe(t.Boolean)
-})
 class TabloComponent<T extends {}> extends React.PureComponent<Tablo.Props<T>> {
   static defaultProps: TabloDefaultProps = {
     rowClassNameGetter: () => "",
@@ -163,11 +135,14 @@ class TabloComponent<T extends {}> extends React.PureComponent<Tablo.Props<T>> {
       }
     ).map((ch, key) => (ch.type as React.SFC<any>)({ key, ...ch.props }));
 
-    t.assert(
-      columnsOrGroups.length ===
-        ([] as any[]).concat(children || Object.keys(data[0])).length,
-      "There are extraneous children in the Grid. One should use only Column or ColumnGroup"
-    );
+    if (
+      columnsOrGroups.length !==
+      ([] as any[]).concat(children || Object.keys(data[0])).length
+    ) {
+      warn(
+        "There are extraneous children in the Grid. One should use only Column or ColumnGroup"
+      );
+    }
 
     const rowClassNameGetter = (index: number) => {
       return cx(

--- a/src/Tablo/plugins/columnsReorder/DNDHeader.tsx
+++ b/src/Tablo/plugins/columnsReorder/DNDHeader.tsx
@@ -8,7 +8,7 @@ import {
   DragSourceSpec,
   DragSourceCollector
 } from "react-dnd";
-import { props, t, ReactChildren, Children } from "../../../utils";
+import { Children } from "../../../utils";
 import FlexView from "react-flexview";
 import { findDOMNode } from "../../../utils";
 
@@ -119,24 +119,6 @@ const columnType = ({ tabloUniqueId }: DNDHeader.Props) =>
 
 @(DragSource(columnType, columnSource, collectSource) as any)
 @(DropTarget(columnType, columnTarget, collectTarget) as any)
-@props({
-  connectDragSource: t.Function,
-  connectDragPreview: t.Function,
-  isDragAllowed: t.Boolean,
-  isDragging: t.Boolean,
-  //
-  connectDropTarget: t.Function,
-  isOver: t.Boolean,
-  canDrop: t.Boolean,
-  onDrop: t.maybe(t.Function),
-  onDragHover: t.maybe(t.Function),
-  //
-  name: t.String,
-  index: t.Integer,
-  isDropAllowed: t.Function,
-  tabloUniqueId: t.String,
-  children: ReactChildren
-})
 export default class DNDHeader extends React.PureComponent<DNDHeader.Props> {
   render() {
     const {

--- a/src/Tablo/plugins/columnsReorder/columnsReorderGrid.tsx
+++ b/src/Tablo/plugins/columnsReorder/columnsReorderGrid.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { props, t, find } from "../../../utils";
+import { find } from "../../../utils";
 
 import * as cx from "classnames";
 import sortBy = require("lodash/sortBy");
@@ -18,8 +18,6 @@ import ColumnGroup from "../../ColumnGroup";
 import Header, { defaultHeader } from "../../Header";
 import DNDHeader from "./DNDHeader";
 import { getArrayChildren } from "../../utils";
-
-const { maybe, list } = t;
 
 export default <T extends {}>(
   Grid: React.ComponentClass<Tablo.Props<T>>
@@ -162,17 +160,6 @@ export default <T extends {}>(
       return <Grid {...this.getLocals(this.props)} />;
     }
   }
-
-  props(
-    {
-      // transform, manipulate
-      className: maybe(t.String),
-      // add
-      columnsOrder: maybe(list(t.String)),
-      onColumnsReorder: maybe(t.Function)
-    },
-    { strict: false }
-  )(ColumnsReorderGrid);
 
   return dragDropContextHTML5Backend(ColumnsReorderGrid);
 };

--- a/src/TextOverflow/TextOverflow.tsx
+++ b/src/TextOverflow/TextOverflow.tsx
@@ -1,26 +1,10 @@
 import * as React from "react";
 import omit = require("lodash/omit");
 import debounce = require("lodash/debounce");
-import { props, t, ObjectOverwrite, Children } from "../utils";
+import { ObjectOverwrite, Children } from "../utils";
 import { warn } from "../utils/log";
 import { ResizeSensor } from "../ResizeSensor/ResizeSensor";
 import { Popover } from "../Popover/Popover";
-
-export const Props = {
-  children: t.maybe(t.Function),
-  label: t.maybe(t.union([t.String, t.Number])),
-  popover: t.maybe(
-    t.interface({
-      position: t.maybe(t.enums.of(["top", "bottom", "left", "right"])),
-      content: t.Nil
-    })
-  ),
-  lazy: t.maybe(t.Boolean),
-  delayWhenLazy: t.maybe(t.Integer),
-  id: t.maybe(t.String),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
 
 export type TextOverflowDefaultProps = {
   /** tooltip delay if the component is lazy */
@@ -61,7 +45,6 @@ export type State = {
 /**
  * Text view which, if string content is too large, trims it and shows the full content on "hover".
  */
-@props(Props, { strict: false })
 export class TextOverflow extends React.Component<TextOverflow.Props, State> {
   private text: HTMLSpanElement | null = null;
   private textWithoutEllipsis: HTMLSpanElement | null = null;

--- a/src/TextOverflow/TextOverflowTouch.tsx
+++ b/src/TextOverflow/TextOverflowTouch.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { TooltipTouch, Props } from "../Tooltip/TooltipTouch";
+import { TooltipTouch } from "../Tooltip/TooltipTouch";
 import { Tooltip } from "../Tooltip/Tooltip";
-import { props, ObjectOverwrite } from "../utils";
+import { ObjectOverwrite } from "../utils";
 
 export namespace TextOverflowTouch {
   export type Props = {
@@ -16,8 +16,6 @@ export namespace TextOverflowTouch {
     style?: object;
   };
 }
-
-@props(Props)
 export class TextOverflowTouch extends React.PureComponent<
   TextOverflowTouch.Props
 > {
@@ -36,5 +34,3 @@ export class TextOverflowTouch extends React.PureComponent<
     );
   }
 }
-
-export { Props };

--- a/src/Textarea/Textarea.tsx
+++ b/src/Textarea/Textarea.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { props, t, ObjectOverwrite } from "../utils";
+import { ObjectOverwrite } from "../utils";
 import TextareaAutosize from "react-autosize-textarea";
 
 export type TextareaRequiredProps = ObjectOverwrite<
@@ -23,17 +23,6 @@ export namespace Textarea {
   export type Props = TextareaRequiredProps & Partial<TextareaDefaultProps>;
 }
 
-export const Props = {
-  value: t.String,
-  onChange: t.Function,
-  placeholder: t.maybe(t.String),
-  disabled: t.maybe(t.Boolean),
-  className: t.maybe(t.String),
-  id: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
-
-@props(Props, { strict: false })
 export class Textarea extends React.PureComponent<Textarea.Props> {
   static defaultProps: TextareaDefaultProps = {
     disabled: false

--- a/src/TimePicker/TimePicker.tsx
+++ b/src/TimePicker/TimePicker.tsx
@@ -59,7 +59,7 @@ function validProps({ value, minTime, maxTime }: TimePicker.Props): boolean {
     (minTime == null || isTime(minTime)) &&
     (maxTime == null || isTime(maxTime));
   const minMaxCoherent =
-    minTime != null && maxTime != null && lteTime(minTime, maxTime);
+    minTime == null || maxTime == null || lteTime(minTime, maxTime);
   const valueMoreThanMin =
     value == null || minTime == null || lteTime(minTime, value);
   const valueLessThanMax =

--- a/src/TimePicker/TimePicker.tsx
+++ b/src/TimePicker/TimePicker.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { props, t } from "../utils";
 import * as cx from "classnames";
 import { SingleDropdown } from "../Dropdown";
 import range = require("lodash/range");
@@ -9,6 +8,7 @@ import uniqBy = require("lodash/uniqBy");
 import sortBy = require("lodash/sortBy");
 import { components } from "react-select";
 import find = require("lodash/find");
+import { warn } from "../utils/log";
 
 export const H24 = "24h";
 export const H12 = "12h";
@@ -25,23 +25,18 @@ const lteTime = (minTime: TimePicker.Time, maxTime: TimePicker.Time) =>
   maxTime.hours > minTime.hours ||
   (maxTime.hours === minTime.hours && maxTime.minutes >= minTime.minutes);
 
-const Integer = t.refinement(t.Number, n => n % 1 === 0, "Integer");
-const Hour = t.refinement(Integer, n => n >= 0 && n <= 23, "Hour");
-const Hour12 = t.refinement(Integer, n => n >= 1 && n <= 12, "Hour12");
-const Minute = t.refinement(Integer, n => n >= 0 && n <= 59, "Minute");
-const TimeFormat = t.enums.of([H12, H24], "TimeFormat");
-const Time = t.struct(
-  {
-    hours: Hour,
-    minutes: Minute
-  },
-  "Time"
-);
+const isInteger = (n: number): boolean => n % 1 === 0;
+const isHour = (n: number): boolean => isInteger(n) && n >= 0 && n <= 23;
+const isHour12 = (n: number): boolean => isInteger(n) && n >= 0 && n <= 12;
+const isMinute = (n: number): boolean => isInteger(n) && n >= 0 && n <= 59;
+const isTime = (time: TimePicker.Props["value"]): boolean =>
+  time != null && isHour(time.hours) && isMinute(time.minutes);
 
 const isValidHoursInTimeFormat = (
   hours: number | null,
   timeFormat: TimePicker.TimeFormat
-): hours is number => (timeFormat === H24 ? Hour.is(hours) : Hour12.is(hours));
+): hours is number =>
+  hours == null ? false : timeFormat === H24 ? isHour(hours) : isHour12(hours);
 
 const getComponents = (
   timeFormatter?: TimePicker.TimeFormatter
@@ -58,28 +53,19 @@ const getComponents = (
     : {};
 };
 
-const Props = t.refinement(
-  t.struct({
-    onChange: t.Function,
-    value: t.maybe(Time),
-    minTime: t.maybe(Time),
-    maxTime: t.maybe(Time),
-    placeholder: t.maybe(t.String),
-    timeFormat: t.maybe(TimeFormat),
-    timeFormatter: t.maybe(t.Function),
-    searchable: t.Boolean,
-    size: t.enums.of(["medium", "small"]),
-    id: t.maybe(t.String),
-    className: t.maybe(t.String),
-    style: t.maybe(t.Object),
-    menuPosition: t.enums.of(["bottom", "top"]),
-    disabled: t.maybe(t.Boolean)
-  }),
-  ({ value, minTime, maxTime }: any) =>
-    lteTime(minTime, maxTime) &&
-    (!value || (lteTime(value, maxTime) && lteTime(minTime, value))),
-  "Props"
-);
+function validProps({ value, minTime, maxTime }: TimePicker.Props): boolean {
+  const validTimes =
+    (value == null || isTime(value)) &&
+    (minTime == null || isTime(minTime)) &&
+    (maxTime == null || isTime(maxTime));
+  const minMaxCoherent =
+    minTime != null && maxTime != null && lteTime(minTime, maxTime);
+  const valueMoreThanMin =
+    value == null || minTime == null || lteTime(minTime, value);
+  const valueLessThanMax =
+    value == null || maxTime == null || lteTime(value, maxTime);
+  return validTimes && minMaxCoherent && valueMoreThanMin && valueLessThanMax;
+}
 
 const formatTime24 = ({ hours, minutes }: TimePicker.Time) =>
   `${pad(hours)}:${pad(minutes)}`;
@@ -149,7 +135,11 @@ const parseInTimeFormat = (
   const minutes =
     !_minutes || numberRegex.test(_minutes) ? parseInt(_minutes, 10) : null;
 
-  if (isValidHoursInTimeFormat(hours, timeFormat) && Minute.is(minutes)) {
+  if (
+    isValidHoursInTimeFormat(hours, timeFormat) &&
+    minutes != null &&
+    isMinute(minutes)
+  ) {
     return { hours, minutes, originalInput: cleanedInput };
   } else if (isValidHoursInTimeFormat(hours, timeFormat)) {
     return { originalInput: cleanedInput };
@@ -162,7 +152,11 @@ const createTimeList = (
   { hours, minutes }: TimePicker.Time,
   timeFormat: TimePicker.TimeFormat
 ): Array<TimePicker.TimeAndFormat> => {
-  if (!isValidHoursInTimeFormat(hours, timeFormat) || !Minute.is(minutes)) {
+  if (
+    !isValidHoursInTimeFormat(hours, timeFormat) ||
+    !minutes ||
+    !isMinute(minutes)
+  ) {
     const hoursList = range(0, 24);
     const minutesList = range(0, 60, interval);
     return flatten(
@@ -283,7 +277,6 @@ type TimeDropdownOption = {
   label: string;
 };
 
-@props(Props)
 export class TimePicker extends React.Component<
   TimePicker.Props,
   { inputValue: string }
@@ -299,6 +292,16 @@ export class TimePicker extends React.Component<
   };
 
   state = { inputValue: "" };
+
+  componentDidMount() {
+    if (process.env.NODE_ENV !== "production") {
+      if (!validProps(this.props)) {
+        warn(
+          "Invalid props provided: `value`, `minTime` or `maxTime` are not valid times or not coherent"
+        );
+      }
+    }
+  }
 
   _onChange = (value: TimeDropdownOption) => {
     // interface with component user is always in H24
@@ -356,13 +359,4 @@ export class TimePicker extends React.Component<
 }
 
 // must be exported after TimePicker class in order to be compatible with react-styleguide (see #1153)
-export {
-  toOption,
-  parseInTimeFormat,
-  createTimeList,
-  filterTime,
-  makeOptions,
-  TimeFormat,
-  Time,
-  Props
-};
+export { toOption, parseInTimeFormat, createTimeList, filterTime, makeOptions };

--- a/src/Toaster/TimerToast.tsx
+++ b/src/Toaster/TimerToast.tsx
@@ -1,16 +1,5 @@
 import * as React from "react";
 import omit = require("lodash/omit");
-import { props, t, ReactChildren } from "../utils";
-
-export const Props = {
-  children: ReactChildren,
-  onTimeout: t.Function,
-  duration: t.Number,
-  uniqueKey: t.maybe(t.String),
-  className: t.maybe(t.String),
-  id: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
 
 export type TimerToastProps = {
   children: JSX.Element;
@@ -26,7 +15,6 @@ export type State = {
   completed: boolean;
 };
 
-@props(Props)
 export class TimerToast extends React.Component<TimerToastProps, State> {
   private timer: number | null = null;
 

--- a/src/Toaster/Toaster.tsx
+++ b/src/Toaster/Toaster.tsx
@@ -2,27 +2,9 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as cx from "classnames";
 import * as ReactTransitionGroup from "react-transition-group/TransitionGroup";
-import { props, t, ReactChildren, findDOMNode, Children } from "../utils";
+import { findDOMNode, Children } from "../utils";
 import { warn } from "../utils/log";
 import { TransitionWrapper } from "../TransitionWrapper/TransitionWrapper";
-
-export const Props = {
-  children: ReactChildren,
-  attachTo: t.maybe(t.String),
-  transitionGroup: t.maybe(t.Object),
-  transitionStyles: t.maybe(t.Object),
-  transitionEnterTimeout: t.Number,
-  transitionLeaveTimeout: t.Number,
-  position: t.enums.of([
-    "top-left",
-    "top-right",
-    "bottom-left",
-    "bottom-right"
-  ]),
-  id: t.maybe(t.String),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
 
 export type ToasterDefaultProps = {
   /** custom settings for `ReactTransitionGroup` */
@@ -55,7 +37,6 @@ type ToasterDefaultedProps = ToasterRequiredProps & ToasterDefaultProps;
 /**
  * Renders and animates toasts (children) inline or in a portal
  */
-@props(Props)
 export class Toaster extends React.Component<Toaster.Props> {
   private toaster: HTMLElement | null = null;
 

--- a/src/Toggle/Toggle.tsx
+++ b/src/Toggle/Toggle.tsx
@@ -1,18 +1,6 @@
 import * as React from "react";
-import { props, t } from "../utils";
 import * as cx from "classnames";
 import { warn } from "../utils/log";
-
-export const Props = {
-  value: t.maybe(t.Boolean),
-  onChange: t.maybe(t.Function),
-  disabled: t.maybe(t.Boolean),
-  size: t.maybe(t.union([t.String, t.Number])),
-  onFocus: t.maybe(t.Function),
-  onBlur: t.maybe(t.Function),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
 
 export type ToggleDefaultProps = {};
 
@@ -41,7 +29,6 @@ type ToggleDefaultedProps = ToggleRequiredProps & ToggleDefaultProps;
 /**
  * A nice animated Toggle rendered using only CSS
  */
-@props(Props)
 export class Toggle extends React.PureComponent<Toggle.Props> {
   private checkbox: HTMLInputElement | null = null;
 
@@ -60,7 +47,7 @@ export class Toggle extends React.PureComponent<Toggle.Props> {
   };
 
   getHalfSize(size: string | number) {
-    if (t.String.is(size)) {
+    if (typeof size === "string") {
       const unitMatch = /[a-z]+$/.exec(size); // only match characters at the end
       const number = parseFloat(size);
       const unit = unitMatch ? unitMatch[0] : "";

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -1,13 +1,6 @@
 import * as React from "react";
 import * as cx from "classnames";
-import {
-  t,
-  ReactChildren,
-  stateClassUtil,
-  props,
-  ObjectOverwrite,
-  Children
-} from "../utils";
+import { stateClassUtil, ObjectOverwrite, Children } from "../utils";
 import { FormattedText } from "../FormattedText/FormattedText";
 import { Popover } from "../Popover/Popover";
 
@@ -46,20 +39,6 @@ export namespace Tooltip {
 
 type TooltipDefaultedProps = TooltipRequiredProps & TooltipDefaultProps;
 
-export const Props = {
-  children: ReactChildren,
-  popover: t.refinement<Popover.Props["popover"]>(
-    t.Object,
-    p => t.String.is(p.content) && t.Nil.is(p.event)
-  ),
-  type: t.enums.of(["light", "dark"]),
-  size: t.enums.of(["small", "big"]),
-  className: t.maybe(t.String),
-  id: t.maybe(t.String),
-  style: t.maybe(t.Object)
-};
-
-@props(Props)
 export class Tooltip extends React.PureComponent<Tooltip.Props> {
   static defaultProps: TooltipDefaultProps = {
     type: "dark",

--- a/src/Tooltip/TooltipTouch.tsx
+++ b/src/Tooltip/TooltipTouch.tsx
@@ -1,13 +1,7 @@
 import * as React from "react";
 import * as cx from "classnames";
-import {
-  Tooltip,
-  TooltipDefaultProps,
-  TooltipRequiredProps,
-  Props
-} from "./Tooltip";
+import { Tooltip, TooltipDefaultProps, TooltipRequiredProps } from "./Tooltip";
 import View from "react-flexview";
-import { props } from "../utils";
 import { findDOMNode } from "../utils";
 
 export type State = {
@@ -24,7 +18,6 @@ export namespace TooltipTouch {
 
 type TooltipTouchDefaultedProps = TooltipRequiredProps & TooltipDefaultProps;
 
-@props(Props)
 export class TooltipTouch extends React.PureComponent<Tooltip.Props, State> {
   static defaultProps: TooltipDefaultProps = {
     type: "dark",
@@ -148,5 +141,3 @@ export class TooltipTouch extends React.PureComponent<Tooltip.Props, State> {
     );
   }
 }
-
-export { Props };

--- a/src/TransitionWrapper/TransitionWrapper.tsx
+++ b/src/TransitionWrapper/TransitionWrapper.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import * as cx from "classnames";
 import omit = require("lodash/omit");
-import { props, t, ReactChildren } from "../utils";
 
 export type TransitionWrapperDefaultProps<CP> = {
   /** object with inline-style for each transition event. It's also possible to use `css` classes (formatted in kebab-case) */
@@ -50,38 +49,24 @@ export type State = {
   transitionClassName?: string;
 };
 
-const ReactClass = t.irreducible(
-  "ReactClass",
-  x =>
-    x &&
-    x.prototype &&
-    (x.prototype instanceof React.Component ||
-      t.Function.is(x.prototype.render))
-);
-
-export const Props = {
-  children: ReactChildren,
-  component: t.maybe(t.union([ReactClass, t.String])),
-  transitionStyles: t.maybe(
-    t.struct({
-      enter: t.maybe(t.Object),
-      enterActive: t.maybe(t.Object),
-      default: t.maybe(t.Object),
-      leave: t.maybe(t.Object),
-      leaveActive: t.maybe(t.Object)
-    })
-  ),
-  transitionEnterTimeout: t.Number,
-  transitionLeaveTimeout: t.Number,
-  onLeave: t.maybe(t.Function),
-  className: t.maybe(t.String),
-  style: t.maybe(t.Object)
+const Props: Record<
+  | keyof TransitionWrapperRequiredProps
+  | keyof TransitionWrapperDefaultProps<unknown>,
+  true
+> = {
+  children: true,
+  component: true,
+  transitionStyles: true,
+  transitionEnterTimeout: true,
+  transitionLeaveTimeout: true,
+  onLeave: true,
+  className: true,
+  style: true
 };
 
 /**
  * To be used with `ReactTransitionGroup` to show transitions for a component
  */
-@props(Props, { strict: false })
 export class TransitionWrapper<CP extends {}> extends React.PureComponent<
   TransitionWrapper.Props<CP>,
   State

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,17 +1,8 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as cx from "classnames";
-import {
-  props,
-  ReactElement,
-  ReactChild,
-  ReactChildren,
-  ReactNode
-} from "tcomb-react";
-import * as t from "tcomb";
 import _find = require("lodash/find");
 
-export { props, t, ReactElement, ReactChild, ReactChildren, ReactNode };
 export const stateClassUtil = (classes: string[]): string =>
   cx(classes.map(cl => `is-${cl}`));
 
@@ -23,10 +14,6 @@ type Props = {
 export const getContextWrapper = (
   contextTypes = {}
 ): React.ComponentType<Props> => {
-  @props({
-    context: t.maybe(t.Object),
-    children: ReactChildren
-  })
   class ContextWrapper extends React.Component<Props> {
     static childContextTypes = contextTypes;
 

--- a/typings/tcomb-react.d.ts
+++ b/typings/tcomb-react.d.ts
@@ -1,1 +1,0 @@
-declare module "tcomb-react";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2992,14 +2992,6 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-doctrine@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-0.7.2.tgz#7cb860359ba3be90e040b26b729ce4bfa654c523"
-  integrity sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=
-  dependencies:
-    esutils "^1.1.6"
-    isarray "0.0.1"
-
 doctrine@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
@@ -3429,11 +3421,6 @@ estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
-
-esutils@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-1.1.6.tgz#c01ccaa9ae4b897c6d0c3e210ae52f3c7a844375"
-  integrity sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -4037,11 +4024,6 @@ get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
-
-get-comments@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/get-comments/-/get-comments-1.0.1.tgz#196759101bbbc4facf13060caaedd4870dee55be"
-  integrity sha1-GWdZEBu7xPrPEwYMqu3Uhw3uVb4=
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.0"
@@ -5170,11 +5152,6 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
-
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -8148,16 +8125,6 @@ react@16.5.0:
     prop-types "^15.6.2"
     schedule "^0.3.0"
 
-react@>=0.13.0:
-  version "16.8.3"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.3.tgz#c6f988a2ce895375de216edcfaedd6b9a76451d9"
-  integrity sha512-3UoSIsEq8yTJuSu0luO1QQWYbgGEILm+eJl2QN/VLDi7hL+EN18M3q3oVZwmVzzBJ3DkM7RMdRwBmZZ+b4IzSA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.13.3"
-
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -9470,37 +9437,7 @@ tar@^4, tar@^4.1.1:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
-tcomb-doc@^0.5.0:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/tcomb-doc/-/tcomb-doc-0.5.2.tgz#d58a653a3007e3649127864010c558a7bf666d1e"
-  integrity sha1-1YplOjAH42SRJ4ZAEMVYp79mbR4=
-  dependencies:
-    tcomb "^3.0.0"
-
-tcomb-react@0.9.3:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/tcomb-react/-/tcomb-react-0.9.3.tgz#44713e1d2e8c2ff744b8ed6579bf77aed23b0efc"
-  integrity sha1-RHE+HS6ML/dEuO1leb93rtI7Dvw=
-  dependencies:
-    doctrine "0.7.2"
-    get-comments "1.0.1"
-    react ">=0.13.0"
-    tcomb-doc "^0.5.0"
-    tcomb-validation "^3.0.0"
-
-tcomb-validation@^3.0.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/tcomb-validation/-/tcomb-validation-3.4.1.tgz#a7696ec176ce56a081d9e019f8b732a5a8894b65"
-  integrity sha512-urVVMQOma4RXwiVCa2nM2eqrAomHROHvWPuj6UkDGz/eb5kcy0x6P0dVt6kzpUZtYMNoAqJLWmz1BPtxrtjtrA==
-  dependencies:
-    tcomb "^3.0.0"
-
-tcomb@3.2.22:
-  version "3.2.22"
-  resolved "https://registry.yarnpkg.com/tcomb/-/tcomb-3.2.22.tgz#4b99e7ebaf243ede608c2f3440b63f48036f5631"
-  integrity sha512-/e7XkvYEd5FMeH283cjEXrLCaQGR9pI9QlAiMTMJTfs5J9Ba9MlA2pmbG5JUOjCaisVB/CJGyJm/ixuyzJAc5A==
-
-tcomb@^3, tcomb@^3.0.0, tcomb@^3.2.15:
+tcomb@^3, tcomb@^3.2.15:
   version "3.2.29"
   resolved "https://registry.yarnpkg.com/tcomb/-/tcomb-3.2.29.tgz#32404fe9456d90c2cf4798682d37439f1ccc386c"
   integrity sha512-di2Hd1DB2Zfw6StGv861JoAF5h/uQVu/QJp2g8KVbtfKnoHdBQl5M32YWq6mnSYBQ1vFFrns5B1haWJL7rKaOQ==


### PR DESCRIPTION
Closes #1360

As expected, the only interesting cases are the one previously involving tcomb `refinement`s. In a single case, it was possible to encode it at type-level (`TabbedPanel` tabs should be non-empty). For all the other cases (TimePicker, Meter mainly) I didn't invest time in expressing the invariants at type level, only reused the same checks performed at runtime inside of `componentDidMount`, and warning in case of issues.

## Test Plan

All checks are passing. This PR should have no impact at runtime, and I decided to not mark it as breaking for this reason. Let me know your thoughts

### tests performed

> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.

### tests not performed (domain coverage)

> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
