### PR TITLE
#1427: FormField components should have a prop packing all inner component's props instead of spreading them (closes #1427)

### DIFF
--- a/src/FormField/CheckboxField.tsx
+++ b/src/FormField/CheckboxField.tsx
@@ -21,7 +21,9 @@ type NonDefaultProps = {
   style?: React.CSSProperties;
   /** an optional id passed to the input component */
   id?: string;
-} & Checkbox.Props;
+  /** the properties of the checkbox*/
+  checkboxProps: Checkbox.Props;
+};
 
 type InternalProps = DefaultProps & NonDefaultProps;
 
@@ -38,26 +40,20 @@ export class CheckboxField extends React.PureComponent<InternalProps> {
     const {
       label,
       required,
-      className: _className,
+      className,
       id,
       viewProps,
-      disabled,
       checkboxRenderer,
-      ..._checkboxProps
+      checkboxProps
     } = this.props;
-    const className = cx("checkbox-field", _className);
-    const checkboxProps = {
-      ..._checkboxProps,
-      disabled
-    };
 
     return (
       <FormField
         label={label}
         required={required}
-        className={className}
+        className={cx("checkbox-field", className)}
         viewProps={viewProps}
-        disabled={disabled}
+        disabled={checkboxProps.disabled}
         id={id}
         horizontal
         onLabelClick={() => checkboxProps.onChange(!checkboxProps.value)}

--- a/src/FormField/DatePickerField.tsx
+++ b/src/FormField/DatePickerField.tsx
@@ -21,7 +21,9 @@ type NonDefaultProps = {
   className?: string;
   /** an optional style object to pass to top level element of the component */
   style?: React.CSSProperties;
-} & DatePicker.Props;
+  /** the properties of the datepicker */
+  datePickerProps: DatePicker.Props;
+};
 
 type InternalProps = DefaultProps & NonDefaultProps;
 
@@ -37,25 +39,24 @@ export class DatePickerField extends React.PureComponent<InternalProps> {
     const {
       label,
       required,
-      className: _className,
+      className,
       viewProps,
-      disabled,
       hint,
-      datePickerRenderer
+      datePickerRenderer,
+      datePickerProps
     } = this.props;
-    const className = cx("date-picker-field", _className);
 
     return (
       <FormField
         label={label}
         required={required}
-        className={className}
+        className={cx("date-picker-field", className)}
         viewProps={viewProps}
-        disabled={disabled}
+        disabled={datePickerProps.disabled}
         hint={hint}
         render={(onFocus, onBlur) =>
           datePickerRenderer({
-            ...this.props,
+            ...datePickerProps,
             onFocusChange: focus => {
               focus ? onFocus() : onBlur();
             }

--- a/src/FormField/InputField.tsx
+++ b/src/FormField/InputField.tsx
@@ -21,7 +21,7 @@ type NonDefaultProps = {
   className?: string;
   /** an optional style object to pass to top level element of the component */
   style?: React.CSSProperties;
-  /** the properties fo the input */
+  /** the properties of the input */
   inputProps: Input.Props;
 };
 

--- a/src/FormField/InputField.tsx
+++ b/src/FormField/InputField.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { ObjectOmit } from "../utils";
 import * as cx from "classnames";
 import Input from "../Input";
 import { FormField } from "./FormField";
@@ -9,21 +8,22 @@ type DefaultProps = {
   inputRenderer: (props: Input.Props) => JSX.Element;
 };
 
-type FieldProps = {
+type NonDefaultProps = {
   /** the label for the field */
   label: FormField.Props["label"];
   /** whether the field is required */
   required?: FormField.Props["required"];
   /** optional props to pass to the wrapping View */
   viewProps?: FormField.Props["viewProps"];
+  /** an optional hint describing what's the expected value for the field (e.g. sample value or short description) */
   hint?: FormField.Props["hint"];
   /** an optional class name to pass to top level element of the component */
   className?: string;
   /** an optional style object to pass to top level element of the component */
   style?: React.CSSProperties;
+  /** the properties fo the input */
+  inputProps: Input.Props;
 };
-
-type NonDefaultProps = FieldProps & ObjectOmit<Input.Props, keyof FieldProps>;
 
 type InternalProps = DefaultProps & NonDefaultProps;
 
@@ -40,26 +40,20 @@ export class InputField extends React.PureComponent<InternalProps> {
     const {
       label,
       required,
-      className: _className,
+      className,
       viewProps,
       hint,
-      disabled,
       inputRenderer,
-      ..._inputProps
+      inputProps
     } = this.props;
-    const className = cx("input-field", _className);
-    const inputProps = {
-      ..._inputProps,
-      disabled
-    };
 
     return (
       <FormField
         label={label}
         required={required}
-        className={className}
+        className={cx("input-field", className)}
         viewProps={viewProps}
-        disabled={disabled}
+        disabled={inputProps.disabled}
         hint={hint}
         render={(onFocus, onBlur) =>
           inputRenderer({ ...inputProps, onFocus, onBlur })

--- a/src/FormField/MultiDropdownField.tsx
+++ b/src/FormField/MultiDropdownField.tsx
@@ -23,7 +23,9 @@ type NonDefaultProps<OptionType> = {
   style?: React.CSSProperties;
   /** an optional id passed to the dropdown component */
   id?: string;
-} & Dropdown.Props<OptionType>;
+  /** the properties of the dropwdown */
+  dropdownProps: Dropdown.Props<OptionType>;
+};
 
 type InternalProps<OptionType> = NonDefaultProps<OptionType> &
   DefaultProps<OptionType>;
@@ -44,29 +46,20 @@ export class MultiDropdownField<OptionType> extends React.PureComponent<
     const {
       label,
       required,
-      className: _className,
+      className,
       viewProps,
-      isDisabled,
       hint,
       dropdownRenderer,
-      id,
-      ..._dropdownProps
+      dropdownProps
     } = this.props;
-    const className = cx("dropdown-field", _className);
-
-    const dropdownProps = {
-      ..._dropdownProps,
-      isDisabled,
-      id
-    };
 
     return (
       <FormField
         label={label}
         required={required}
-        className={className}
+        className={cx("dropdown-field", className)}
         viewProps={viewProps}
-        disabled={isDisabled}
+        disabled={dropdownProps.isDisabled}
         hint={hint}
         render={(onFocus, onBlur) =>
           dropdownRenderer({ ...dropdownProps, onFocus, onBlur })

--- a/src/FormField/PasswordInputField.tsx
+++ b/src/FormField/PasswordInputField.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { ObjectOmit } from "../utils";
 import * as cx from "classnames";
 import { PasswordInput } from "../Input";
 import { FormField } from "./FormField";
@@ -9,7 +8,7 @@ type DefaultProps = {
   passwordInputRenderer: (props: PasswordInput.Props) => JSX.Element;
 };
 
-type FieldProps = {
+type NonDefaultProps = {
   /** the label for the field */
   label: FormField.Props["label"];
   /** whether the field is required */
@@ -22,10 +21,9 @@ type FieldProps = {
   className?: string;
   /** an optional style object to pass to top level element of the component */
   style?: React.CSSProperties;
+  /** the properties of password input */
+  passwordInputProps: PasswordInput.Props;
 };
-
-type NonDefaultProps = FieldProps &
-  ObjectOmit<PasswordInput.Props, keyof FieldProps>;
 
 type InternalProps = NonDefaultProps & DefaultProps;
 
@@ -42,29 +40,23 @@ export class PasswordInputField extends React.PureComponent<InternalProps> {
     const {
       label,
       required,
-      className: _className,
+      className,
       viewProps,
-      disabled,
       hint,
       passwordInputRenderer,
-      ..._inputProps
+      passwordInputProps
     } = this.props;
-    const className = cx("password-input-field", _className);
-    const inputProps = {
-      ..._inputProps,
-      disabled
-    };
 
     return (
       <FormField
         label={label}
         required={required}
-        className={className}
+        className={cx("password-input-field", className)}
         viewProps={viewProps}
-        disabled={disabled}
+        disabled={passwordInputProps.disabled}
         hint={hint}
         render={(onFocus, onBlur) =>
-          passwordInputRenderer({ ...inputProps, onFocus, onBlur })
+          passwordInputRenderer({ ...passwordInputProps, onFocus, onBlur })
         }
       />
     );

--- a/src/FormField/PasswordInputField.tsx
+++ b/src/FormField/PasswordInputField.tsx
@@ -21,7 +21,7 @@ type NonDefaultProps = {
   className?: string;
   /** an optional style object to pass to top level element of the component */
   style?: React.CSSProperties;
-  /** the properties of password input */
+  /** the properties of the password input */
   passwordInputProps: PasswordInput.Props;
 };
 

--- a/src/FormField/RadioGroupField.tsx
+++ b/src/FormField/RadioGroupField.tsx
@@ -21,7 +21,9 @@ type NonDefaultProps = {
   style?: React.CSSProperties;
   /** an optional id passed to the input component */
   id?: string;
-} & RadioGroup.Props;
+  /** the properties of the radio group */
+  radioGroupProps: RadioGroup.Props;
+};
 
 type InternalProps = NonDefaultProps & DefaultProps;
 
@@ -40,26 +42,20 @@ export class RadioGroupField extends React.PureComponent<InternalProps> {
     const {
       label,
       required,
-      className: _className,
+      className,
       id,
       viewProps,
-      disabled,
       radioGroupRenderer,
-      ..._radioGroupProps
+      radioGroupProps
     } = this.props;
-    const className = cx("radio-group-field", _className);
-    const radioGroupProps = {
-      ..._radioGroupProps,
-      disabled
-    };
 
     return (
       <FormField
         label={label}
         required={required}
-        className={className}
+        className={cx("radio-group-field", className)}
         viewProps={viewProps}
-        disabled={disabled}
+        disabled={radioGroupProps.disabled}
         id={id}
         render={() => radioGroupRenderer({ ...radioGroupProps })}
       />

--- a/src/FormField/SingleDropdownField.tsx
+++ b/src/FormField/SingleDropdownField.tsx
@@ -23,7 +23,9 @@ type NonDefaultProps<OptionType> = {
   style?: React.CSSProperties;
   /** an optional id passed to the dropdown component */
   id?: string;
-} & Dropdown.Props<OptionType>;
+  /** the properties of the dropdown */
+  dropdownProps: Dropdown.Props<OptionType>;
+};
 
 type InternalProps<OptionType> = NonDefaultProps<OptionType> &
   DefaultProps<OptionType>;
@@ -44,29 +46,20 @@ export class SingleDropdownField<OptionType> extends React.PureComponent<
     const {
       label,
       required,
-      className: _className,
+      className,
       viewProps,
-      isDisabled,
       hint,
       dropdownRenderer,
-      id,
-      ..._dropdownProps
+      dropdownProps
     } = this.props;
-    const className = cx("dropdown-field", _className);
-
-    const dropdownProps = {
-      ..._dropdownProps,
-      isDisabled,
-      id
-    };
 
     return (
       <FormField
         label={label}
         required={required}
-        className={className}
+        className={cx("dropdown-field", className)}
         viewProps={viewProps}
-        disabled={isDisabled}
+        disabled={dropdownProps.isDisabled}
         hint={hint}
         render={(onFocus, onBlur) =>
           dropdownRenderer({ ...dropdownProps, onFocus, onBlur })

--- a/src/FormField/TextareaField.tsx
+++ b/src/FormField/TextareaField.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { ObjectOmit } from "../utils";
 import * as cx from "classnames";
 import Textarea from "../Textarea";
 import { FormField } from "./FormField";
@@ -9,7 +8,7 @@ type DefaultProps = {
   textareaRenderer: (props: Textarea.Props) => JSX.Element;
 };
 
-type FieldProps = {
+type NonDefaultProps = {
   /** the label for the field */
   label: FormField.Props["label"];
   /** whether the field is required */
@@ -22,10 +21,10 @@ type FieldProps = {
   className?: string;
   /** an optional style object to pass to top level element of the component */
   style?: React.CSSProperties;
+  /** the properties of the text area */
+  textareaProps: Textarea.Props;
 };
 
-type NonDefaultProps = FieldProps &
-  ObjectOmit<Textarea.Props, keyof FieldProps>;
 type InternalProps = NonDefaultProps & DefaultProps;
 
 export namespace TextareaField {
@@ -41,25 +40,19 @@ export class TextareaField extends React.PureComponent<InternalProps> {
     const {
       label,
       required,
-      className: _className,
+      className,
       viewProps,
-      disabled,
       hint,
       textareaRenderer,
-      ..._textareaProps
+      textareaProps
     } = this.props;
-    const className = cx("textarea-field", _className);
-    const textareaProps: Textarea.Props = {
-      ..._textareaProps,
-      disabled
-    };
     return (
       <FormField
         label={label}
         required={required}
-        className={className}
+        className={cx("textarea-field", className)}
         viewProps={viewProps}
-        disabled={disabled}
+        disabled={textareaProps.disabled}
         hint={hint}
         render={(onFocus, onBlur) =>
           textareaRenderer({ ...textareaProps, onFocus, onBlur })

--- a/src/FormField/TimePickerField.tsx
+++ b/src/FormField/TimePickerField.tsx
@@ -21,7 +21,9 @@ type NonDefaultProps = {
   className?: string;
   /** an optional style object to pass to top level element of the component */
   style?: React.CSSProperties;
-} & TimePicker.Props;
+  /** the properties of the time picker */
+  timePickerProps: TimePicker.Props;
+};
 
 type InternalProps = NonDefaultProps & DefaultProps;
 
@@ -38,26 +40,20 @@ export class TimePickerField extends React.PureComponent<InternalProps> {
     const {
       label,
       required,
-      className: _className,
+      className,
       viewProps,
-      disabled,
       hint,
       timePickerRenderer,
-      ..._timePickerProps
+      timePickerProps
     } = this.props;
-    const className = cx("time-picker-field", _className);
-    const timePickerProps = {
-      ..._timePickerProps,
-      disabled
-    };
 
     return (
       <FormField
         label={label}
         required={required}
-        className={className}
+        className={cx("time-picker-field", className)}
         viewProps={viewProps}
-        disabled={disabled}
+        disabled={timePickerProps.disabled}
         hint={hint}
         render={() => timePickerRenderer({ ...timePickerProps })}
       />

--- a/src/FormField/ToggleField.tsx
+++ b/src/FormField/ToggleField.tsx
@@ -21,7 +21,9 @@ type NonDefaultProps = {
   style?: React.CSSProperties;
   /** an optional id passed to the input component */
   id?: string;
-} & Toggle.Props;
+  /** the properties of the toggle */
+  toggleProps: Toggle.Props;
+};
 
 type InternalProps = NonDefaultProps & DefaultProps;
 
@@ -38,26 +40,20 @@ export class ToggleField extends React.PureComponent<InternalProps> {
     const {
       label,
       required,
-      className: _className,
+      className,
       id,
       viewProps,
-      disabled,
       toggleRenderer,
-      ..._toggleProps
+      toggleProps
     } = this.props;
-    const className = cx("toggle-field", _className);
-    const toggleProps = {
-      ..._toggleProps,
-      disabled
-    };
 
     return (
       <FormField
         label={label}
         required={required}
-        className={className}
+        className={cx("toggle-field", className)}
         viewProps={viewProps}
-        disabled={disabled}
+        disabled={toggleProps.disabled}
         id={id}
         horizontal
         onLabelClick={() => toggleProps.onChange(!toggleProps.value)}


### PR DESCRIPTION
Closes #1427

## Test Plan

### tests performed

<img width="385" alt="Schermata 2020-03-27 alle 15 59 03" src="https://user-images.githubusercontent.com/34537387/77769315-f7c19480-7043-11ea-8568-194487650a0f.png">

All the components in the FormField module now have a mandatory property requiring an object containing all the properties of their inner component. This object has the same type of the `Props` of the inner component.

No change in the UX has been introduced
