### PR TITLE
#1436: Add parameter to customize anchor of Menu component (closes #1436)

### DIFF
--- a/src/Menu/Examples.md
+++ b/src/Menu/Examples.md
@@ -4,29 +4,29 @@
 intialState = { isOpen: false };
 
 function toggleOpen() {
-  setState({ isOpen: !state.isOpen })
+  setState({ isOpen: !state.isOpen });
 }
 
 function onClick(option) {
-  alert(`${option.title} clicked`)
+  alert(`${option.title} clicked`);
 }
 
 const { isOpen } = state;
 
 const options = [
   {
-    title: 'Preferences',
-    type: 'item',
+    title: "Preferences",
+    type: "item",
     onClick
   },
   {
-    title: 'Change password',
-    type: 'item',
+    title: "Change password",
+    type: "item",
     onClick
   },
   {
-    title: 'Logout',
-    type: 'item',
+    title: "Logout",
+    type: "item",
     onClick
   }
 ];
@@ -35,33 +35,50 @@ const menuProps = {
   onOpen: toggleOpen,
   onClose: toggleOpen,
   isOpen,
-  options
+  options,
+  position: "bottom"
 };
 
 const icon = isOpen ? (
-  <svg version='1.1' xmlns='http://www.w3.org/2000/svg' height='12' viewBox='0 0 32 32'>
-    <path fill='#9098a7' d='M0.932 20.708l13.333-13.333c0.482-0.479 1.146-0.775 1.88-0.775s1.398 0.296 1.88 0.776l13.333 13.333c0.399 0.463 0.641 1.071 0.641 1.735 0 1.473-1.194 2.667-2.667 2.667-0.664 0-1.271-0.243-1.738-0.644l-13.33-13.33h3.76l-13.333 13.333c-0.492 0.572-1.217 0.932-2.025 0.932-1.473 0-2.667-1.194-2.667-2.667 0-0.809 0.36-1.533 0.929-2.023l0.003-0.003z'></path>
+  <svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    height="12"
+    viewBox="0 0 32 32"
+  >
+    <path
+      fill="#9098a7"
+      d="M0.932 20.708l13.333-13.333c0.482-0.479 1.146-0.775 1.88-0.775s1.398 0.296 1.88 0.776l13.333 13.333c0.399 0.463 0.641 1.071 0.641 1.735 0 1.473-1.194 2.667-2.667 2.667-0.664 0-1.271-0.243-1.738-0.644l-13.33-13.33h3.76l-13.333 13.333c-0.492 0.572-1.217 0.932-2.025 0.932-1.473 0-2.667-1.194-2.667-2.667 0-0.809 0.36-1.533 0.929-2.023l0.003-0.003z"
+    />
   </svg>
 ) : (
-  <svg version="1.1" xmlns="http://www.w3.org/2000/svg" height="12" viewBox="0 0 32 32">
-    <path fill="#9098a7" d="M0.647 11.102l13.456 13.456c0.486 0.484 1.157 0.783 1.897 0.783s1.411-0.299 1.897-0.783l13.456-13.456c0.402-0.467 0.647-1.080 0.647-1.751 0-1.486-1.205-2.691-2.691-2.691-0.67 0-1.283 0.245-1.754 0.65l-13.452 13.453h3.794l-13.456-13.456c-0.468-0.402-1.080-0.647-1.75-0.647-1.486 0-2.691 1.205-2.691 2.691 0 0.67 0.245 1.283 0.65 1.754l-0.003-0.004z"></path>
+  <svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    height="12"
+    viewBox="0 0 32 32"
+  >
+    <path
+      fill="#9098a7"
+      d="M0.647 11.102l13.456 13.456c0.486 0.484 1.157 0.783 1.897 0.783s1.411-0.299 1.897-0.783l13.456-13.456c0.402-0.467 0.647-1.080 0.647-1.751 0-1.486-1.205-2.691-2.691-2.691-0.67 0-1.283 0.245-1.754 0.65l-13.452 13.453h3.794l-13.456-13.456c-0.468-0.402-1.080-0.647-1.75-0.647-1.486 0-2.691 1.205-2.691 2.691 0 0.67 0.245 1.283 0.65 1.754l-0.003-0.004z"
+    />
   </svg>
 );
 
-<FlexView hAlignContent='right' style={{ border: '1px solid #ced0da' }}>
+<FlexView hAlignContent="right" style={{ border: "1px solid #ced0da" }}>
   <Menu {...menuProps}>
-    <FlexView vAlignContent='center' className='user-menu'>
-      <FlexView shrink={false} className='user-avatar'>
-        <img src='avatarMenu.png' />
+    <FlexView vAlignContent="center" className="user-menu">
+      <FlexView shrink={false} className="user-avatar">
+        <img src="avatarMenu.png" />
       </FlexView>
       <FlexView column grow>
-        <FlexView className='user-name'>Jordan J.</FlexView>
-        <FlexView className='user-role'>Administrator</FlexView>
+        <FlexView className="user-name">Jordan J.</FlexView>
+        <FlexView className="user-role">Administrator</FlexView>
       </FlexView>
-      <FlexView shrink={false} style={{ cursor: 'pointer' }}>
+      <FlexView shrink={false} style={{ cursor: "pointer" }}>
         {icon}
       </FlexView>
     </FlexView>
   </Menu>
-</FlexView>
+</FlexView>;
 ```

--- a/src/Menu/Examples.md
+++ b/src/Menu/Examples.md
@@ -35,8 +35,7 @@ const menuProps = {
   onOpen: toggleOpen,
   onClose: toggleOpen,
   isOpen,
-  options,
-  position: "bottom"
+  options
 };
 
 const icon = isOpen ? (

--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -27,10 +27,10 @@ export type MenuDefaultProps = {
   isOpen: boolean;
   /** whether the menu should be closed when clicking outside */
   dismissOnClickOutside: boolean;
-  /** wheter the menu should be rendered on top or at the bottom of the trigger (bottom by default) */
+  /** whether the menu should be rendered on top or at the bottom of the trigger (bottom by default) */
   position: "top" | "bottom";
-  /** wheter the menu should be aligned with the start, the end or the center of the trigger (end by default) */
-  anchor: "start" | "center" | "end";
+  /** whether the menu should be aligned with the start, the end or the center of the trigger (end by default) */
+  anchor: Popover.Props["popover"]["anchor"];
 };
 
 export namespace Menu {

--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -29,6 +29,8 @@ export type MenuDefaultProps = {
   dismissOnClickOutside: boolean;
   /** wheter the menu should be rendered on top or at the bottom of the trigger */
   position: "top" | "bottom";
+  /** wheter the menu should be aligned with the start, the end or the center of the trigger */
+  anchor: "start" | "center" | "end";
 };
 
 export namespace Menu {
@@ -42,12 +44,6 @@ type MenuDefaultedProps = MenuRequiredProps & MenuDefaultProps;
  *  A menu with actions
  */
 export class Menu extends React.PureComponent<Menu.Props> {
-  static defaultProps: MenuDefaultProps = {
-    isOpen: false,
-    dismissOnClickOutside: true,
-    position: "bottom"
-  };
-
   getActionsMenuMaxHeight = (): number | undefined => {
     if (this.props.maxHeight) {
       return this.props.maxHeight;
@@ -77,7 +73,8 @@ export class Menu extends React.PureComponent<Menu.Props> {
       isOpen,
       onClose,
       onOpen,
-      position
+      position,
+      anchor
     } = this.props as MenuDefaultedProps;
 
     const maxHeight = this.getActionsMenuMaxHeight();
@@ -88,10 +85,10 @@ export class Menu extends React.PureComponent<Menu.Props> {
           isOpen,
           dismissOnClickOutside,
           position,
+          anchor,
           onShow: onOpen,
           onHide: onClose,
           event: "click",
-          anchor: "end",
           className: "actions-menu-popover",
           dismissOnScroll: false,
           content: menuRenderer ? (

--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -27,9 +27,9 @@ export type MenuDefaultProps = {
   isOpen: boolean;
   /** whether the menu should be closed when clicking outside */
   dismissOnClickOutside: boolean;
-  /** wheter the menu should be rendered on top or at the bottom of the trigger */
+  /** wheter the menu should be rendered on top or at the bottom of the trigger (bottom by default) */
   position: "top" | "bottom";
-  /** wheter the menu should be aligned with the start, the end or the center of the trigger */
+  /** wheter the menu should be aligned with the start, the end or the center of the trigger (end by default) */
   anchor: "start" | "center" | "end";
 };
 
@@ -84,8 +84,8 @@ export class Menu extends React.PureComponent<Menu.Props> {
         popover={{
           isOpen,
           dismissOnClickOutside,
-          position,
-          anchor,
+          position: position ? position : "bottom",
+          anchor: anchor ? anchor : "end",
           onShow: onOpen,
           onHide: onClose,
           event: "click",


### PR DESCRIPTION
Closes #1436

## Test Plan

### tests performed

The horizontal alignment of the Menu is customizable using the `anchor` prop.

Position is "bottom" and anchor is "end" by default, to avoid introduce breaking changes. This also fixes an error in the examples.

`anchor="start"`           |  `anchor="end"` or not defined
:-------------------------:|:-------------------------:
<img width="289" alt="Schermata 2020-04-10 alle 16 59 52" src="https://user-images.githubusercontent.com/34537387/79000631-46dfed00-7b4d-11ea-99fb-188c45b83c35.png">  |  <img width="289" alt="Schermata 2020-04-10 alle 16 59 30" src="https://user-images.githubusercontent.com/34537387/79000629-45162980-7b4d-11ea-803a-d89ea054c712.png">





