### PR TITLE
#1435: componentWillReceiveProps has been renamed

### DIFF
--- a/src/Button/StatefulButton.tsx
+++ b/src/Button/StatefulButton.tsx
@@ -104,20 +104,20 @@ export class StatefulButton extends React.PureComponent<StatefulButton.Props, St
     }
   };
 
-  componentWillReceiveProps(props: StatefulButton.Props) {
+  componentDidUpdate(prevProps: StatefulButton.Props) {
     if (process.env.NODE_ENV !== 'production') {
-      if (props.stableSuccess !== this.props.stableSuccess) {
+      if (this.props.stableSuccess !== prevProps.stableSuccess) {
         warn('StatefulButton: changing the "stableSuccess" prop is not supported');
       }
     }
 
-    if (props.buttonState) {
+    if (this.props.buttonState) {
       if (this.timeoutId) {
         clearTimeout(this.timeoutId);
         this.timeoutId = null;
       }
     }
-    if (props.baseState !== this.props.baseState) {
+    if (this.props.baseState !== prevProps.baseState) {
       if (this.state.internalState === 'processing') {
         this.resetInternalStateAfterProcessing = true;
       } else {

--- a/src/DateField/DateField.tsx
+++ b/src/DateField/DateField.tsx
@@ -64,18 +64,18 @@ export class DateField extends React.PureComponent<DateField.Props, State> {
       }
     : initialState;
 
-  componentWillReceiveProps(nextProps: DateField.Props) {
-    if (!nextProps.value && this.props.value) {
+  componentDidUpdate(prevProps: DateField.Props) {
+    if (!this.props.value && prevProps.value) {
       // "value" has become "undefined"
       this.setState({ day: '', month: '', year: '', isValid: false });
     } else if (
-      (nextProps.value && !this.props.value) ||
-      (nextProps.value &&
-        this.props.value &&
-        nextProps.value.getTime() !== this.props.value.getTime())
+      (this.props.value && !prevProps.value) ||
+      (this.props.value &&
+        prevProps.value &&
+        this.props.value.getTime() !== prevProps.value.getTime())
     ) {
       // "value" exists and has changed
-      const { day, month, year } = parseDate(nextProps.value);
+      const { day, month, year } = parseDate(this.props.value);
 
       // this logic is needed to avoid transforming the user input "07" in the parsed number "7"
       if (

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -126,9 +126,9 @@ export class DatePicker extends React.PureComponent<DatePicker.Props, State> {
     this.dayRenderer = this.dayRendererFactory();
   }
 
-  componentWillReceiveProps(newProps: DatePicker.Props) {
-    if (newProps.locale !== this.props.locale) {
-      moment.locale(newProps.locale);
+  componentDidUpdate(prevProps: DatePicker.Props) {
+    if (this.props.locale !== prevProps.locale) {
+      moment.locale(this.props.locale);
     }
   }
 

--- a/src/Input/ConfirmationInput.tsx
+++ b/src/Input/ConfirmationInput.tsx
@@ -74,10 +74,10 @@ export class ConfirmationInput extends React.PureComponent<ConfirmationInput.Pro
     value: this.props.initialValue || ''
   };
 
-  componentWillReceiveProps({ initialValue }: ConfirmationInput.Props) {
-    if (initialValue !== this.props.initialValue) {
+  componentDidUpdate(prevProps: ConfirmationInput.Props) {
+    if (this.props.initialValue !== prevProps.initialValue) {
       this.setState({
-        value: initialValue || ''
+        value: this.props.initialValue || ''
       });
     }
   }

--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -115,14 +115,14 @@ export class Popover extends React.Component<Popover.Props, State> {
     }
   }
 
-  componentWillReceiveProps(nextProps: Popover.Props) {
-    this.updateDebouncedMousedEvents(nextProps);
+  componendDidUpdate() {
+    this.updateDebouncedMousedEvents(this.props);
     this.saveValuesFromNodeTree();
 
-    const isOpenChanged = this.getPopoverProps().isOpen !== this.getPopoverProps(nextProps).isOpen;
+    const isOpenChanged = this.getPopoverProps().isOpen !== this.getPopoverProps(this.props).isOpen;
 
     if (!this.isStateful() && isOpenChanged) {
-      this.onPopoverOpenChange(nextProps);
+      this.onPopoverOpenChange(this.props);
     }
   }
 

--- a/src/Tablo/plugins/scrollable/scrollableGrid.tsx
+++ b/src/Tablo/plugins/scrollable/scrollableGrid.tsx
@@ -14,14 +14,14 @@ export default <T extends {}>(
       scrollTop: this.props.scrollTop
     };
 
-    componentWillReceiveProps(nextProps: Tablo.Props<T>) {
-      const scrollTopDidntChanged = nextProps.scrollTop === this.props.scrollTop;
+    componentDidUpdate(prevProps: Tablo.Props<T>) {
+      const scrollTopDidntChanged = this.props.scrollTop === prevProps.scrollTop;
       const rowsSelectionChanged =
-        nextProps.selectedRows &&
         this.props.selectedRows &&
-        nextProps.selectedRows[0] !== this.props.selectedRows[0];
+        prevProps.selectedRows &&
+        this.props.selectedRows[0] !== prevProps.selectedRows[0];
       this.setState({
-        scrollTop: scrollTopDidntChanged && rowsSelectionChanged ? undefined : nextProps.scrollTop
+        scrollTop: scrollTopDidntChanged && rowsSelectionChanged ? undefined : this.props.scrollTop
       });
     }
 

--- a/src/TextOverflow/TextOverflow.tsx
+++ b/src/TextOverflow/TextOverflow.tsx
@@ -58,8 +58,8 @@ export class TextOverflow extends React.Component<TextOverflow.Props, State> {
     !this.props.lazy && this.verifyOverflow();
   }
 
-  componentWillReceiveProps(nextProps: TextOverflow.Props) {
-    if (!this.props.lazy && nextProps.label !== this.props.label) {
+  componentDidUpdate(prevProps: TextOverflow.Props) {
+    if (!prevProps.lazy && this.props.label !== prevProps.label) {
       this.reset();
     }
   }

--- a/src/Toaster/Toaster.tsx
+++ b/src/Toaster/Toaster.tsx
@@ -151,13 +151,10 @@ export class Toaster extends React.Component<Toaster.Props> {
     }
   }
 
-  componentDidUpdate() {
-    this.renderToaster();
-  }
-
-  componentWillReceiveProps(nextProps: Toaster.Props) {
-    if (this.props.attachTo !== nextProps.attachTo) {
+  componentDidUpdate(prevProps: Toaster.Props) {
+    if (prevProps.attachTo !== this.props.attachTo) {
       warn('You can\'t change "attachTo" prop after the first render!');
     }
+    this.renderToaster();
   }
 }

--- a/src/Toggle/Toggle.tsx
+++ b/src/Toggle/Toggle.tsx
@@ -36,8 +36,8 @@ export class Toggle extends React.PureComponent<Toggle.Props> {
     this.updateCheckbox(this.props as ToggleDefaultedProps);
   }
 
-  componentWillReceiveProps(nextProps: Toggle.Props) {
-    this.updateCheckbox(nextProps as ToggleDefaultedProps);
+  componentDidUpdate() {
+    this.updateCheckbox(this.props as ToggleDefaultedProps);
   }
 
   updateCheckbox = (props: ToggleDefaultedProps) => {


### PR DESCRIPTION
Closes #1435

[as suggested](https://github.com/buildo/react-components/issues/1435#issuecomment-615166577) I replaced all the usages of deprecated `componentWillReceiveProps` with `componentDidUpdate`.

Looking at the code seems like nothing should change, but I'm not sure about how we should test this.

Showroom works correctly and `yarn test` detects no issue.

Several warnings about `componentWillReceiveProps` being renamed will still be displayed due to dependencies.
