### PR TITLE
#1409: DatePicker has 1px left border on open calendar

### DIFF
--- a/src/DatePicker/datePicker.scss
+++ b/src/DatePicker/datePicker.scss
@@ -131,6 +131,10 @@ $date-picker-outside-day-background: $brc-white !default;
     z-index: $date-picker-z-index;
 
     .DayPicker {
+      width: 229px !important;
+      height: 199px !important;
+      box-shadow: none !important;
+
       .DayPicker_weekHeaders {
         margin-left: 0;
 

--- a/src/DatePicker/datePicker.scss
+++ b/src/DatePicker/datePicker.scss
@@ -132,7 +132,6 @@ $date-picker-outside-day-background: $brc-white !default;
 
     .DayPicker {
       width: 229px !important;
-      height: 199px !important;
       box-shadow: none !important;
 
       .DayPicker_weekHeaders {
@@ -174,9 +173,8 @@ $date-picker-outside-day-background: $brc-white !default;
         right: 10px;
       }
 
-      // HACK to hide the bottom padding
       .DayPicker_transitionContainer {
-        height: 200px !important;
+        height: 199px !important;
       }
 
       .CalendarDay {


### PR DESCRIPTION
Closes #1409

## Test Plan

### tests performed

remove both the horizontal and vertical empty space and also remove the double border

#### before
<img width="464" alt="Schermata 2020-05-08 alle 15 17 36" src="https://user-images.githubusercontent.com/34537387/81409243-0faa2f00-913f-11ea-8734-f8e0adff5a2d.png">

#### after
<img width="481" alt="Schermata 2020-05-08 alle 15 20 30" src="https://user-images.githubusercontent.com/34537387/81409488-7e878800-913f-11ea-867e-50ef4ed0afd8.png">


