### PR TITLE
Forward data-* attributes on 11 more components

### DIFF
--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import cx from 'classnames';
-import { Children } from '../utils';
+import { Children, DataAttributes, pickDataAttributes } from '../utils';
 import FlexView from 'react-flexview';
 
 export namespace Badge {
@@ -13,7 +13,7 @@ export namespace Badge {
     className?: string;
     /** an optional style object to pass to top level element of the component */
     style?: React.CSSProperties;
-  };
+  } & DataAttributes;
 }
 
 export class Badge extends React.PureComponent<Badge.Props> {
@@ -22,7 +22,12 @@ export class Badge extends React.PureComponent<Badge.Props> {
     const className = cx('badge', { active }, _className);
 
     return (
-      <FlexView vAlignContent="center" hAlignContent="center" {...{ className, style }}>
+      <FlexView
+        vAlignContent="center"
+        hAlignContent="center"
+        {...{ className, style }}
+        {...pickDataAttributes(this.props)}
+      >
         <span className="badge-label">{label}</span>
       </FlexView>
     );

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import cx from 'classnames';
 import FlexView from 'react-flexview';
+import { DataAttributes, pickDataAttributes } from '../utils';
 
 export type CheckboxRequiredProps = {
   /** value */
@@ -26,7 +27,7 @@ export type CheckboxDefaultProps = {
 };
 
 export namespace Checkbox {
-  export type Props = CheckboxRequiredProps & Partial<CheckboxDefaultProps>;
+  export type Props = CheckboxRequiredProps & Partial<CheckboxDefaultProps> & DataAttributes;
 }
 
 export class Checkbox extends React.PureComponent<Checkbox.Props> {
@@ -66,6 +67,7 @@ export class Checkbox extends React.PureComponent<Checkbox.Props> {
         )}
         id={id}
         style={style}
+        {...pickDataAttributes(this.props)}
       >
         <FlexView
           shrink={false}

--- a/src/DateField/DateField.tsx
+++ b/src/DateField/DateField.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import every = require('lodash/every');
 import cx from 'classnames';
 import View from 'react-flexview';
+import { DataAttributes, pickDataAttributes } from '../utils';
 
 export namespace DateField {
   export type Props = {
@@ -25,7 +26,7 @@ export namespace DateField {
     style?: React.CSSProperties;
     /** an optional id to pass to top level element of the component */
     id?: string;
-  };
+  } & DataAttributes;
 }
 
 export type State = {
@@ -165,6 +166,7 @@ export class DateField extends React.PureComponent<DateField.Props, State> {
         })}
         id={id}
         style={style}
+        {...pickDataAttributes(this.props)}
       >
         <input
           className="day-field"

--- a/src/Divider/Divider.tsx
+++ b/src/Divider/Divider.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import cx from 'classnames';
+import { DataAttributes, pickDataAttributes } from '../utils';
 
 export type DividerDefaultProps = {
   /** divider orientation (vertical | horizontal) */
@@ -15,7 +16,7 @@ export type DividerDefaultProps = {
 export namespace Divider {
   export type Orientation = 'horizontal' | 'vertical';
   export type Size = 'small' | 'medium' | 'large' | 'no-margin';
-  export type Props = Partial<DividerDefaultProps>;
+  export type Props = Partial<DividerDefaultProps> & DataAttributes;
 }
 type DividerDefaultedProps = DividerDefaultProps;
 
@@ -31,6 +32,12 @@ export class Divider extends React.PureComponent<Divider.Props> {
 
   render() {
     const { orientation, style, size, className } = this.props as DividerDefaultedProps;
-    return <div className={cx('divider', className, orientation, size)} style={style} />;
+    return (
+      <div
+        className={cx('divider', className, orientation, size)}
+        style={style}
+        {...pickDataAttributes(this.props)}
+      />
+    );
   }
 }

--- a/src/FormField/FormField.tsx
+++ b/src/FormField/FormField.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import cx from 'classnames';
 import View from 'react-flexview';
 import Popover from '../Popover';
-import { ObjectOmit } from '../utils';
+import { DataAttributes, ObjectOmit, pickDataAttributes } from '../utils';
 
 export namespace FormField {
   export type Props = {
@@ -37,7 +37,7 @@ export namespace FormField {
           type: 'tooltip';
           popover?: ObjectOmit<Popover.Props['popover'], 'content'>;
         };
-  };
+  } & DataAttributes;
 }
 
 const leftArrow = (
@@ -148,6 +148,7 @@ export class FormField extends React.PureComponent<FormField.Props, State> {
         className={className}
         onMouseOver={this.stateChange('mouseover', true)}
         onMouseOut={this.stateChange('mouseover', false)}
+        {...pickDataAttributes(this.props)}
       >
         <View grow column={!horizontal}>
           {horizontal ? [fieldComponent, labelComponent] : [labelComponent, fieldComponent]}

--- a/src/Menu/ActionsMenu.tsx
+++ b/src/Menu/ActionsMenu.tsx
@@ -3,7 +3,7 @@ import cx from 'classnames';
 import partial = require('lodash/partial');
 import FlexView from 'react-flexview';
 import { Divider } from '../Divider/Divider';
-import { findDOMNode } from '../utils';
+import { DataAttributes, findDOMNode, pickDataAttributes } from '../utils';
 
 export type ActionsMenuRequiredProps = {
   options?: ActionsMenu.Option[];
@@ -27,7 +27,7 @@ export namespace ActionsMenu {
 
   export type OptionClickHandler = (o: Option) => void;
 
-  export type Props = ActionsMenuRequiredProps & Partial<ActionsMenuDefaultProps>;
+  export type Props = ActionsMenuRequiredProps & Partial<ActionsMenuDefaultProps> & DataAttributes;
 }
 
 export type State = {
@@ -118,7 +118,11 @@ export class ActionsMenu extends React.PureComponent<ActionsMenu.Props, State> {
     const { onOptionClick } = this;
 
     return (
-      <div className="actions-menu" style={{ ...style, maxHeight }}>
+      <div
+        className="actions-menu"
+        style={{ ...style, maxHeight }}
+        {...pickDataAttributes(this.props)}
+      >
         {this.templateRenderedOptions({ options, onOptionClick })}
       </div>
     );

--- a/src/NavBar/NavBar.tsx
+++ b/src/NavBar/NavBar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import cx from 'classnames';
-import { Children } from '../utils';
+import { Children, DataAttributes, pickDataAttributes } from '../utils';
 import FlexView from 'react-flexview';
 
 export namespace NavBar {
@@ -25,7 +25,7 @@ export namespace NavBar {
     className?: string;
     /** add custom css style */
     style?: React.CSSProperties;
-  };
+  } & DataAttributes;
 }
 
 export class NavBar extends React.PureComponent<NavBar.Props> {
@@ -44,7 +44,13 @@ export class NavBar extends React.PureComponent<NavBar.Props> {
     const { left, center, right, maxWidth } = content;
 
     return (
-      <FlexView className={className} style={style} vAlignContent="center" hAlignContent="center">
+      <FlexView
+        className={className}
+        style={style}
+        vAlignContent="center"
+        hAlignContent="center"
+        {...pickDataAttributes(this.props)}
+      >
         <FlexView
           vAlignContent="center"
           hAlignContent="center"

--- a/src/Panel/Panel.tsx
+++ b/src/Panel/Panel.tsx
@@ -5,6 +5,7 @@ import { PanelHeader } from './PanelHeader';
 import capitalize = require('lodash/capitalize');
 import { LoadingSpinner } from '../LoadingSpinner/LoadingSpinner';
 import FlexView from 'react-flexview';
+import { DataAttributes, pickDataAttributes } from '../utils';
 
 export type PanelDefaultProps = {
   style: React.CSSProperties;
@@ -54,7 +55,7 @@ export namespace Panel {
     menu?: Children;
   };
 
-  export type Props = PanelRequiredProps & Partial<PanelDefaultProps>;
+  export type Props = PanelRequiredProps & Partial<PanelDefaultProps> & DataAttributes;
 }
 
 /** A simple component used to group elements in a box. */
@@ -237,6 +238,7 @@ export class Panel extends React.PureComponent<Panel.Props> {
         style={style}
         column
         onClick={!isExpanded ? toggleExpanded : undefined}
+        {...pickDataAttributes(this.props)}
       >
         {this.templateSoftLoading({ softLoading, isExpanded })}
         {this.templateHeader({ header, isExpanded, toggleExpanded })}

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import cx from 'classnames';
 import FlexView from 'react-flexview';
+import { DataAttributes, pickDataAttributes } from '../utils';
 
 export type RadioOption<T> = {
   label: string;
@@ -28,7 +29,9 @@ export type RadioGroupDefaultProps = {
 };
 
 export namespace RadioGroup {
-  export type Props<T> = RadioGroupRequiredProps<T> & Partial<RadioGroupDefaultProps>;
+  export type Props<T> = RadioGroupRequiredProps<T> &
+    Partial<RadioGroupDefaultProps> &
+    DataAttributes;
 }
 
 export class RadioGroup<T> extends React.PureComponent<RadioGroup.Props<T>> {
@@ -66,6 +69,7 @@ export class RadioGroup<T> extends React.PureComponent<RadioGroup.Props<T>> {
           },
           className
         )}
+        {...pickDataAttributes(this.props)}
       >
         {options.map(option => (
           <FlexView

--- a/src/TimePicker/TimePicker.tsx
+++ b/src/TimePicker/TimePicker.tsx
@@ -9,6 +9,7 @@ import sortBy = require('lodash/sortBy');
 import { components, OptionProps, SingleValueProps } from 'react-select';
 import find = require('lodash/find');
 import { warn } from '../utils/log';
+import { DataAttributes, pickDataAttributes } from '../utils';
 
 export const H24 = '24h';
 export const H12 = '12h';
@@ -235,7 +236,7 @@ export namespace TimePicker {
     originalInput?: string;
   } & Partial<Time>;
 
-  export type Props = RequiredProps & Partial<DefaultProps>;
+  export type Props = RequiredProps & Partial<DefaultProps> & DataAttributes;
 }
 type TimePickerDefaultedProps = RequiredProps & DefaultProps;
 type TimeDropdownOption = {
@@ -314,6 +315,7 @@ export class TimePicker extends React.Component<TimePicker.Props, { inputValue: 
         onBlur={() => this.forceUpdate()}
         menuPlacement={menuPosition}
         isDisabled={disabled}
+        {...pickDataAttributes(this.props)}
       />
     );
   }

--- a/src/Toggle/Toggle.tsx
+++ b/src/Toggle/Toggle.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import cx from 'classnames';
 import { warn } from '../utils/log';
+import { DataAttributes, pickDataAttributes } from '../utils';
 
 export type ToggleDefaultProps = {};
 
@@ -22,7 +23,7 @@ export type ToggleRequiredProps = {
 };
 
 export namespace Toggle {
-  export type Props = ToggleRequiredProps & Partial<ToggleDefaultProps>;
+  export type Props = ToggleRequiredProps & Partial<ToggleDefaultProps> & DataAttributes;
 }
 type ToggleDefaultedProps = ToggleRequiredProps & ToggleDefaultProps;
 
@@ -97,7 +98,7 @@ export class Toggle extends React.PureComponent<Toggle.Props> {
     const className = cx('toggle', { disabled }, _className);
 
     return (
-      <div {...{ className, style }}>
+      <div {...{ className, style }} {...pickDataAttributes(this.props)}>
         <input
           className="toggle-input"
           type="checkbox"


### PR DESCRIPTION
Stacked on top of #1495.

## Summary
- Extend the `data-*` forwarding pattern (introduced in #1495) to 11 additional components: `Checkbox`, `Toggle`, `Badge`, `RadioGroup`, `FormField`, `DateField`, `Panel`, `NavBar`, `Divider`, `ActionsMenu`, `TimePicker`.
- Each component's `Props` is intersected with `DataAttributes`, and `pickDataAttributes(this.props)` is spread onto the component's root element.
- `TimePicker` delegates to `SingleDropdown`, which already handles the react-select wrapper case from #1495.

## Not included (deliberately)
- `Input`, `PasswordInput`, `ConfirmationInput`, `Textarea`: already forward consumer props via rest spread to their 3rd-party roots.
- `Modal`, `Popover`, `Tooltip`, `Menu`: portal/delegation-based renderers where the target for `data-*` is ambiguous — worth a separate design pass if there's demand.

## Test plan
- [ ] Pass `data-testid` to each of the 11 components and verify the attribute lands on the rendered root element.
- [ ] Verify that when no `data-*` props are passed, the rendered DOM is unchanged.
- [ ] `yarn tsc --noEmit` passes on the branch.